### PR TITLE
documents: add thumbnails in brief view

### DIFF
--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -128,6 +128,7 @@
     <table class="table">
       <thead>
         <tr>
+          <th translate>Label</th>
           <th translate>File</th>
           <th translate>Size</th>
           <th></th>
@@ -135,10 +136,8 @@
       </thead>
       <tbody>
         <tr *ngFor="let file of filterFiles(record.metadata._files)">
-          <td>
-            <span class="badge badge-primary" translate *ngIf="file.order === 1">Fichier principal</span>
-            {{ file.key }}
-          </td>
+          <td>{{ file.label | default:'-' }}</td>
+          <td>{{ file.key }}</td>
           <td>{{ file.size | filesize }}</td>
           <td class="text-right">
             <a href (click)="$event.preventDefault(); previewFileKey = file.key; previewModal.show()"

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -14,25 +14,29 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<p class="m-0" *ngIf="record.metadata.institution">
-  <i>{{ record.metadata.institution.name | translate }}</i>
-</p>
-<h4 class="my-2">
-  <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">{{
-    record.metadata.title
-  }}</a>
-  <ng-template #routingLink>
-    <a [routerLink]="detailUrl.link">
-      {{ record.metadata.title[0].mainTitle | languageValue }}
+<div class="row">
+  <div class="col-sm-2">
+    <a [routerLink]="detailUrl.link" *ngIf="thumbnail">
+      <img [src]="thumbnail" class="img-thumbnail img-fluid" [alt]="record.metadata.title[0].mainTitle | languageValue">
     </a>
-  </ng-template>
-</h4>
-<h5 *ngIf="record.metadata.title[0].subtitle" class="text-muted">
-  {{ record.metadata.title[0].subtitle | languageValue }}
-</h5>
-<p>
-  <span class="badge badge-primary mr-1" *ngFor="let author of record.metadata.authors">{{ author.name }}</span>
-</p>
-<div *ngIf="record.metadata.abstracts">
-  {{ record.metadata.abstracts | languageValue | truncateText: 30 }}
+  </div>
+  <div class="col-sm-10">
+    <p class="m-0" *ngIf="record.metadata.institution">
+      <i>{{ record.metadata.institution.name | translate }}</i>
+    </p>
+    <h4 class="my-2">
+      <a [routerLink]="detailUrl.link">
+        {{ record.metadata.title[0].mainTitle | languageValue }}
+      </a>
+    </h4>
+    <h5 *ngIf="record.metadata.title[0].subtitle" class="text-muted">
+      {{ record.metadata.title[0].subtitle | languageValue }}
+    </h5>
+    <p>
+      <span class="badge badge-primary mr-1" *ngFor="let author of record.metadata.authors">{{ author.name }}</span>
+    </p>
+    <div *ngIf="record.metadata.abstracts">
+      {{ record.metadata.abstracts | languageValue | truncateText: 30 }}
+    </div>
+  </div>
 </div>

--- a/projects/sonar/src/app/record/document/document.component.ts
+++ b/projects/sonar/src/app/record/document/document.component.ts
@@ -14,15 +14,43 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Component, Input } from '@angular/core';
-
+import { Component, OnInit } from '@angular/core';
 import { ResultItem } from '@rero/ng-core';
 
 @Component({
   templateUrl: './document.component.html'
 })
-export class DocumentComponent implements ResultItem {
+export class DocumentComponent implements ResultItem, OnInit {
+  // Record object
   record: any;
+
+  // Type of resource
   type: string;
+
+  // Detail URL object
   detailUrl: { link: string, external: boolean };
+
+  // Thumbnail file for record
+  thumbnail: any;
+
+  ngOnInit() {
+    this.loadThumbnail();
+  }
+
+  /**
+   * Load the thumbnail for record
+   */
+  private loadThumbnail() {
+    if (!this.record.metadata._files) {
+      return;
+    }
+
+    const thumbnails = this.record.metadata._files.filter((file: any) => file.type === 'thumbnail');
+
+    if (!thumbnails) {
+      return;
+    }
+
+    this.thumbnail = `/documents/${this.record.metadata.pid}/files/${thumbnails[0].key}`;
+  }
 }


### PR DESCRIPTION
* Adds thumbnails for documents in brief view.
* Changes link to detail in brief view.
* Adds label info of file in detail view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>