### PR TITLE
deposit: show spinner during validation

### DIFF
--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -247,6 +247,7 @@ export class EditorComponent implements OnInit {
         first(),
         switchMap((confirm: boolean) => {
           if (confirm === true) {
+            this.spinner.show();
             return this.depositService.publish(this.deposit.pid);
           }
 
@@ -255,6 +256,7 @@ export class EditorComponent implements OnInit {
         delay(1000)
       )
       .subscribe(() => {
+        this.spinner.hide();
         this.router.navigate(['deposit', this.deposit.pid, 'confirmation']);
       });
   }


### PR DESCRIPTION
* Shows a spinner when a deposit is validated, before redirecting to confirmation page.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>