### PR TITLE
organisations: search route

### DIFF
--- a/projects/sonar/src/app/app-config.service.ts
+++ b/projects/sonar/src/app/app-config.service.ts
@@ -22,6 +22,9 @@ import { environment } from '../environments/environment';
   providedIn: 'root'
 })
 export class AppConfigService extends CoreConfigService {
+  // View key for global search
+  globalSearchViewCode = 'sonar';
+
   /**
    * Constructor.
    */

--- a/projects/sonar/src/app/record/document/aggregation-filter.ts
+++ b/projects/sonar/src/app/record/document/aggregation-filter.ts
@@ -20,6 +20,18 @@ import { Observable, Subscriber } from 'rxjs';
 export class AggregationFilter {
   static translateService: TranslateService;
 
+  // Default code for global search
+  static globalSearchViewCode: string;
+
+  // Current view
+  static view: string;
+
+  /**
+   * Creates an observable emitting the aggregations.
+   *
+   * @param aggregations Object containing the aggregations.
+   * @returns Observable resolving aggregations.
+   */
   static filter(aggregations: object): Observable<any> {
     const obs = new Observable((observer: Subscriber<any>): void => {
       observer.next(AggregationFilter.aggregationFilter(aggregations));
@@ -30,8 +42,20 @@ export class AggregationFilter {
     return obs;
   }
 
-  static aggregationFilter(aggregations: object) {
+  /**
+   * Filter aggregations.
+   *
+   * @param aggregations Object containing the aggregations.
+   * @returns Filtered aggregations.
+   */
+  static aggregationFilter(aggregations: any) {
     const aggs = {};
+
+    // If not in global view, don't display organisation's aggregation.
+    if (this.view !== this.globalSearchViewCode) {
+      delete aggregations.organisation;
+    }
+
     Object.keys(aggregations).forEach(aggregation => {
       // Translate values for document type
       if (aggregation === 'document_type') {

--- a/projects/sonar/src/app/record/organisation/detail/detail.component.html
+++ b/projects/sonar/src/app/record/organisation/detail/detail.component.html
@@ -22,5 +22,15 @@
 
     <dt class="col-sm-3" translate>Name</dt>
     <dd class="col-sm-9">{{ record.metadata.name }}</dd>
+
+    <dt class="col-sm-3" translate>Is shared</dt>
+    <dd class="col-sm-9">
+      <i class="fa fa-{{ record.metadata.isShared ? 'check' : 'close' }}"></i>
+    </dd>
+
+    <dt class="col-sm-3" translate>Is dedicated</dt>
+    <dd class="col-sm-9">
+      <i class="fa fa-{{ record.metadata.isDedicated ? 'check' : 'close' }}"></i>
+    </dd>
   </dl>
 </ng-container>

--- a/projects/sonar/src/assets/i18n/de.json
+++ b/projects/sonar/src/assets/i18n/de.json
@@ -53,6 +53,8 @@
   "ID": "ID",
   "Identifier": "Identifier",
   "Import metadata": "Import metadata",
+  "Is dedicated": "Is dedicated",
+  "Is shared": "Is shared",
   "Label": "Label",
   "Languages": "Languages",
   "Leave a comment for the user...": "Leave a comment for the user...",

--- a/projects/sonar/src/assets/i18n/en.json
+++ b/projects/sonar/src/assets/i18n/en.json
@@ -53,6 +53,8 @@
   "ID": "ID",
   "Identifier": "Identifier",
   "Import metadata": "Import metadata",
+  "Is dedicated": "Is dedicated",
+  "Is shared": "Is shared",
   "Label": "Label",
   "Languages": "Languages",
   "Leave a comment for the user...": "Leave a comment for the user...",

--- a/projects/sonar/src/assets/i18n/fr.json
+++ b/projects/sonar/src/assets/i18n/fr.json
@@ -53,6 +53,8 @@
   "ID": "Identifiant",
   "Identifier": "Identifiant",
   "Import metadata": "Importer les metadata",
+  "Is dedicated": "Is dedicated",
+  "Is shared": "Is shared",
   "Label": "Etiquette",
   "Languages": "Langues",
   "Leave a comment for the user...": "Laisser un commentaire pour l'utilisateur",

--- a/projects/sonar/src/assets/i18n/it.json
+++ b/projects/sonar/src/assets/i18n/it.json
@@ -53,6 +53,8 @@
   "ID": "ID",
   "Identifier": "Identifier",
   "Import metadata": "Import metadata",
+  "Is dedicated": "Is dedicated",
+  "Is shared": "Is shared",
   "Label": "Label",
   "Languages": "Languages",
   "Leave a comment for the user...": "Leave a comment for the user...",

--- a/projects/sonar/src/assets/i18n/messages.json
+++ b/projects/sonar/src/assets/i18n/messages.json
@@ -53,6 +53,8 @@
   "ID": "ID",
   "Identifier": "Identifier",
   "Import metadata": "Import metadata",
+  "Is dedicated": "Is dedicated",
+  "Is shared": "Is shared",
   "Label": "Label",
   "Languages": "Languages",
   "Leave a comment for the user...": "Leave a comment for the user...",


### PR DESCRIPTION
* Uses one route for all organisations search page.
* Updates route data according to the `view` parameter.
* Adds the values for `isShared` and `isDedicated` properties in organisation's detail view.
* Hides aggregation for organisation if the view code is not global.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## How to test

See https://github.com/rero/sonar/pull/234