### PR TITLE
users: rename role publisher

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -36,7 +36,7 @@
             <li class="nav-item" *ngIf="user.is_moderator">
               <a class="nav-link" routerLink="/records/documents" translate>Documents</a>
             </li>
-            <li class="nav-item dropdown" *ngIf="user.is_publisher" dropdown>
+            <li class="nav-item dropdown" *ngIf="user.is_submitter" dropdown>
               <a class="nav-link dropdown-toggle" role="button" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false" dropdownToggle translate>
                 Deposits

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -55,7 +55,7 @@ const routes: Routes = [
         path: 'deposit/:id',
         canActivate: [RoleGuard],
         data: {
-          role: 'publisher'
+          role: 'submitter'
         },
         children: [
           {
@@ -175,7 +175,7 @@ export class AppRoutingModule {
           { path: 'new', component: EditorComponent, canActivate: [CanAddGuard] }
         ],
         data: {
-          role: 'publisher',
+          role: 'submitter',
           showSearchInput: true,
           types: [
             {

--- a/projects/sonar/src/assets/i18n/de.json
+++ b/projects/sonar/src/assets/i18n/de.json
@@ -222,7 +222,7 @@
   "organisation": "Organisations",
   "role_admin": "Admin",
   "role_moderator": "Moderator",
-  "role_publisher": "Submitter",
+  "role_submitter": "Submitter",
   "role_superuser": "Super user",
   "role_user": "User",
   "specific_collections": "Specific collections",

--- a/projects/sonar/src/assets/i18n/en.json
+++ b/projects/sonar/src/assets/i18n/en.json
@@ -222,7 +222,7 @@
   "organisation": "Organisations",
   "role_admin": "Admin",
   "role_moderator": "Moderator",
-  "role_publisher": "Submitter",
+  "role_submitter": "Submitter",
   "role_superuser": "Super user",
   "role_user": "User",
   "specific_collections": "Specific collections",

--- a/projects/sonar/src/assets/i18n/fr.json
+++ b/projects/sonar/src/assets/i18n/fr.json
@@ -222,7 +222,7 @@
   "organisation": "Organisations",
   "role_admin": "Admin",
   "role_moderator": "Moderator",
-  "role_publisher": "Submitter",
+  "role_submitter": "Submitter",
   "role_superuser": "Super user",
   "role_user": "User",
   "specific_collections": "Specific collections",

--- a/projects/sonar/src/assets/i18n/it.json
+++ b/projects/sonar/src/assets/i18n/it.json
@@ -222,7 +222,7 @@
   "organisation": "Organisations",
   "role_admin": "Admin",
   "role_moderator": "Moderator",
-  "role_publisher": "Submitter",
+  "role_submitter": "Submitter",
   "role_superuser": "Super user",
   "role_user": "User",
   "specific_collections": "Specific collections",

--- a/projects/sonar/src/assets/i18n/messages.json
+++ b/projects/sonar/src/assets/i18n/messages.json
@@ -222,7 +222,7 @@
   "organisation": "organisation",
   "role_admin": "role_admin",
   "role_moderator": "role_moderator",
-  "role_publisher": "role_publisher",
+  "role_submitter": "role_submitter",
   "role_superuser": "role_superuser",
   "role_user": "role_user",
   "specific_collections": "specific_collections",

--- a/projects/sonar/src/manual_translations.ts
+++ b/projects/sonar/src/manual_translations.ts
@@ -165,5 +165,5 @@ _('deposit_log_action_ask_for_changes');
 _('role_superuser');
 _('role_admin');
 _('role_moderator');
-_('role_publisher');
+_('role_submitter');
 _('role_user');


### PR DESCRIPTION
* Renames role `publisher` to `submitter`.
* Closes #250.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>