### PR TITLE
documents: improve brief views

### DIFF
--- a/projects/sonar/src/app/app-config.service.ts
+++ b/projects/sonar/src/app/app-config.service.ts
@@ -19,11 +19,31 @@ import { CoreConfigService } from '@rero/ng-core';
 import { environment } from '../environments/environment';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class AppConfigService extends CoreConfigService {
   // View key for global search
   globalSearchViewCode = 'sonar';
+
+  // Languages map.
+  languagesMap = [
+    {
+      code: 'en',
+      bibCode: 'eng',
+    },
+    {
+      code: 'fr',
+      bibCode: 'fre',
+    },
+    {
+      code: 'de',
+      bibCode: 'ger',
+    },
+    {
+      code: 'it',
+      bibCode: 'ita',
+    },
+  ];
 
   /**
    * Constructor.

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -83,6 +83,7 @@ const routes: Routes = [
       adminMode: adminModeDisabled,
       types: [
         {
+          showLabel: false,
           key: 'documents',
           label: 'Documents',
           component: DocumentComponent,

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -46,6 +46,7 @@ import { HttpInterceptor } from './interceptor/http.interceptor';
 import { LanguageValuePipe } from './pipe/language-value.pipe';
 import { DetailComponent as DocumentDetailComponent } from './record/document/detail/detail.component';
 import { DocumentComponent } from './record/document/document.component';
+import { PublicationPipe } from './record/document/publication.pipe';
 import { DetailComponent as OrganisationDetailComponent } from './record/organisation/detail/detail.component';
 import { OrganisationComponent } from './record/organisation/organisation.component';
 import { DetailComponent as UserDetailComponent } from './record/user/detail/detail.component';
@@ -77,7 +78,8 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     FileLinkPipe,
     HighlightJsonPipe,
     ReviewComponent,
-    AdminComponent
+    AdminComponent,
+    PublicationPipe
   ],
   imports: [
     BrowserModule,

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -15,7 +15,7 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <div class="row">
-  <div class="col-sm-2 text-center">
+  <div class="col-2 d-none d-lg-block text-center">
     <ng-container *ngIf="thumbnail">
       <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
         <img [src]="thumbnail" class="img-thumbnail img-fluid p-2"
@@ -33,34 +33,36 @@
         </span>
       </p>
     </ng-container>
-  </div>
-  <div class="col-sm-10">
-    <p class="m-0" *ngIf="record.metadata.organisation">
-      <i>{{ record.metadata.organisation.name | translate }}</i>
+    <p class="my-2" *ngIf="record.metadata.documentType">
+      <small>{{ ('document_type_' + record.metadata.documentType) | translate }}</small>
     </p>
-    <h4 class="my-2">
-      <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">{{
-        record.metadata.title[0].mainTitle | languageValue
-      }}</a>
+  </div>
+  <div class="col-12 col-lg-10">
+    <h4 class="mb-2">
+      <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
+        {{ record.metadata.title[0].mainTitle | languageValue }}<ng-container *ngIf="record.metadata.title[0].subtitle">
+          :&nbsp;{{ record.metadata.title[0].subtitle | languageValue }}</ng-container>
+      </a>
       <ng-template #routingLink>
         <a [routerLink]="detailUrl.link">
-          {{ record.metadata.title[0].mainTitle | languageValue }}
+          {{ record.metadata.title[0].mainTitle | languageValue }}<ng-container
+            *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle | languageValue }}
+          </ng-container>
         </a>
       </ng-template>
     </h4>
-    <h5 *ngIf="record.metadata.title[0].subtitle" class="text-muted">
-      {{ record.metadata.title[0].subtitle | languageValue }}
-    </h5>
-    <p>
-      <ng-container *ngFor="let contributor of record.metadata.contribution">
-        <span class="badge badge-primary mr-1"
-          *ngIf="contributor.agent && contributor.agent.type === 'bf:Person' && contributor.role[0] === 'cre'">
-          {{ contributor.agent.preferred_name }}
-        </span>
+    <p class="mb-0">
+      <ng-container *ngFor="let contributor of record.metadata.contribution; let first = first;">
+        <ng-container *ngIf="!first">&nbsp;;&nbsp;</ng-container>
+        {{ contributor.agent.preferred_name }}
+        <span
+          *ngIf="contributor.role[0] !== 'cre'">({{ ('contribution_role_' + contributor.role[0]) | translate | lowercase }})</span>
       </ng-container>
     </p>
-    <div *ngIf="record.metadata.abstracts">
-      {{ record.metadata.abstracts | languageValue | truncateText: 30 }}
+    <p class="mb-2 d-none d-lg-block" *ngIf="record.metadata.partOf && record.metadata.partOf.length > 0">
+      {{ record.metadata.partOf[0] | publication }}</p>
+    <div class="d-none d-lg-block text-muted text-justify text-small" *ngIf="abstract">
+      {{ abstract | truncateText: 30 }}
     </div>
   </div>
 </div>

--- a/projects/sonar/src/app/record/document/publication.pipe.spec.ts
+++ b/projects/sonar/src/app/record/document/publication.pipe.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { TestBed } from '@angular/core/testing';
+import { TranslateService } from '@rero/ng-core';
+import { mockedConfiguration } from '../../../../tests/utils';
+import { PublicationPipe } from './publication.pipe';
+
+let pipe: PublicationPipe;
+
+describe('PublicationPipe', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule(mockedConfiguration);
+
+    pipe = new PublicationPipe(TestBed.get(TranslateService));
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return empty publication', () => {
+    expect(pipe.transform({})).toBe('');
+  });
+
+  it('should return only document', () => {
+    expect(pipe.transform({ document: { title: 'Journal' } })).toBe('Journal');
+  });
+
+  it('should return document and year', () => {
+    expect(
+      pipe.transform({ document: { title: 'Journal' }, numberingYear: '2000' })
+    ).toBe('Journal, 2000');
+  });
+
+  it('should return document, year and issue', () => {
+    expect(
+      pipe.transform({
+        document: { title: 'Journal' },
+        numberingYear: '2000',
+        numberingIssue: '12',
+      })
+    ).toBe('Journal, 2000, no. 12');
+  });
+
+  it('should return document, year, issue and volume', () => {
+    expect(
+      pipe.transform({
+        document: { title: 'Journal' },
+        numberingYear: '2000',
+        numberingIssue: '12',
+        numberingVolume: '1',
+      })
+    ).toBe('Journal, 2000, vol. 1, no. 12');
+  });
+
+  it('should return document, year, issue, volume and pages', () => {
+    expect(
+      pipe.transform({
+        document: { title: 'Journal' },
+        numberingYear: '2000',
+        numberingIssue: '12',
+        numberingVolume: '1',
+        numberingPages: '20-25',
+      })
+    ).toBe('Journal, 2000, vol. 1, no. 12, p. 20-25');
+  });
+});

--- a/projects/sonar/src/app/record/document/publication.pipe.ts
+++ b/projects/sonar/src/app/record/document/publication.pipe.ts
@@ -1,0 +1,71 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+import { TranslateService } from '@rero/ng-core';
+
+/**
+ * Pipe for displaying publication for a document
+ */
+@Pipe({
+  name: 'publication',
+})
+export class PublicationPipe implements PipeTransform {
+  /**
+   * Constructor.
+   *
+   * @param _translateService TranslateService
+   */
+  constructor(private _translateService: TranslateService) {}
+
+  /**
+   * Transform `partOf` object in text.
+   *
+   * @param value `partOf` object.
+   * @returns Text representing the publication.
+   */
+  transform(value: any): string {
+    const journal: Array<string> = [];
+
+    if (value.document && value.document.title) {
+      journal.push(value.document.title);
+    }
+
+    if (value.numberingYear) {
+      journal.push(value.numberingYear);
+    }
+
+    if (value.numberingVolume) {
+      journal.push(
+        this._translateService.translate('vol.') + ' ' + value.numberingVolume
+      );
+    }
+
+    if (value.numberingIssue) {
+      journal.push(
+        this._translateService.translate('no.') + ' ' + value.numberingIssue
+      );
+    }
+
+    if (value.numberingPages) {
+      journal.push(
+        this._translateService.translate('p.') + ' ' + value.numberingPages
+      );
+    }
+
+    return journal.join(', ');
+  }
+}

--- a/projects/sonar/src/index.html
+++ b/projects/sonar/src/index.html
@@ -18,6 +18,8 @@
   </head>
 
   <body>
-    <sonar-root></sonar-root>
+    <div class="container">
+      <sonar-root></sonar-root>
+    </div>
   </body>
 </html>

--- a/projects/sonar/src/styles.scss
+++ b/projects/sonar/src/styles.scss
@@ -48,3 +48,7 @@ pre {
 .nav-item > a {
   cursor: pointer;
 }
+
+.text-small {
+  font-size: 14px;
+}

--- a/projects/sonar/tests/utils.ts
+++ b/projects/sonar/tests/utils.ts
@@ -15,16 +15,29 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { of } from 'rxjs';
+import { AppModule } from '../src/app/app.module';
+import { DepositService } from '../src/app/deposit/deposit.service';
+import { UserService } from '../src/app/user.service';
 
-export const userTestingService = jasmine.createSpyObj(
-  'UserService', ['loadLoggedUser']
-);
+export const userTestingService = jasmine.createSpyObj('UserService', [
+  'loadLoggedUser',
+]);
 userTestingService.loadLoggedUser.and.returnValue(of({}));
 userTestingService.user$ = of({});
 
-export const depositTestingService = jasmine.createSpyObj(
-  'DepositService', ['getJsonSchema', 'getFiles', 'get']
-);
+export const depositTestingService = jasmine.createSpyObj('DepositService', [
+  'getJsonSchema',
+  'getFiles',
+  'get',
+]);
 depositTestingService.getJsonSchema.and.returnValue(of({}));
 depositTestingService.getFiles.and.returnValue(of({}));
 depositTestingService.get.and.returnValue(of({}));
+
+export const mockedConfiguration = {
+  imports: [AppModule],
+  providers: [
+    { provide: UserService, useValue: userTestingService },
+    { provide: DepositService, useValue: depositTestingService },
+  ],
+};


### PR DESCRIPTION
* Improves the display of brief views for documents.
* Adds a `publicationPipe` for displaying text for document's publications.
* Adds a configuration object to facilitate testing.
* Closes rero/sonar#253.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>