### PR TITLE
project: use ngx-spinner from ng-core.

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -14,8 +14,6 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ngx-spinner [fullScreen]="true" type="ball-spin-clockwise" size="medium" bdColor="rgba(51,51,51,0.2)" color="#000">
-</ngx-spinner>
 <div *ngIf="ready">
   <div *ngIf="user; else errorTemplate">
     <nav class="navbar navbar-expand-sm navbar-dark bg-primary">

--- a/projects/sonar/src/app/_layout/admin/admin.component.spec.ts
+++ b/projects/sonar/src/app/_layout/admin/admin.component.spec.ts
@@ -22,7 +22,6 @@ import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-tr
 import { RecordModule, TranslateLoader } from '@rero/ng-core';
 import { BsLocaleService } from 'ngx-bootstrap';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { NgxSpinnerModule } from 'ngx-spinner';
 import { depositTestingService, userTestingService } from 'projects/sonar/tests/utils';
 import { DepositService } from '../../deposit/deposit.service';
 import { UserService } from '../../user.service';
@@ -39,7 +38,6 @@ describe('AdminComponent', () => {
         RouterTestingModule,
         HttpClientModule,
         CollapseModule.forRoot(),
-        NgxSpinnerModule,
         RecordModule,
         TranslateModule.forRoot({
           loader: {

--- a/projects/sonar/src/app/app.component.html
+++ b/projects/sonar/src/app/app.component.html
@@ -14,4 +14,5 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
+<ngx-spinner type="ball-spin-clockwise" size="medium" bdColor="rgba(51,51,51,0.3)" color="#000"></ngx-spinner>
 <router-outlet></router-outlet>

--- a/projects/sonar/src/app/app.component.spec.ts
+++ b/projects/sonar/src/app/app.component.spec.ts
@@ -21,7 +21,6 @@ import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-tr
 import { RecordModule, TranslateLoader } from '@rero/ng-core';
 import { BsLocaleService } from 'ngx-bootstrap';
 import { CollapseModule } from 'ngx-bootstrap/collapse';
-import { NgxSpinnerModule } from 'ngx-spinner';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -31,7 +30,6 @@ describe('AppComponent', () => {
         RouterTestingModule,
         HttpClientModule,
         CollapseModule.forRoot(),
-        NgxSpinnerModule,
         RecordModule,
         TranslateModule.forRoot({
           loader: {

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -27,7 +27,6 @@ import { CollapseModule } from 'ngx-bootstrap/collapse';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { NgxDropzoneModule } from 'ngx-dropzone';
-import { NgxSpinnerModule } from 'ngx-spinner';
 import { ToastrModule } from 'ngx-toastr';
 import { AppConfigService } from './app-config.service';
 import { AppRoutingModule } from './app-routing.module';
@@ -91,7 +90,6 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     TabsModule.forRoot(),
     TooltipModule.forRoot(),
     ModalModule.forRoot(),
-    NgxSpinnerModule,
     TranslateModule.forRoot({
       loader: {
         provide: BaseTranslateLoader,


### PR DESCRIPTION
* Removes declaration of `ngx-spinner` module as it is exported from ng-core.
* Changes spinner type and size.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>