### PR TITLE
documents: add dissertation property

### DIFF
--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { DatePipe } from '@angular/common';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -112,7 +113,8 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
       provide: CoreConfigService,
       useClass: AppConfigService
     },
-    BsLocaleService
+    BsLocaleService,
+    DatePipe
   ],
   entryComponents: [
     DocumentComponent,

--- a/projects/sonar/src/app/deposit/editor/editor.component.html
+++ b/projects/sonar/src/app/deposit/editor/editor.component.html
@@ -134,6 +134,13 @@
               </dd>
             </ng-container>
 
+            <ng-container *ngIf="deposit.metadata.dissertation">
+              <dt class="col-sm-3" translate>Dissertation</dt>
+              <dd class="col-sm-9">
+                {{ dissertation }}
+              </dd>
+            </ng-container>
+
             <ng-container
               *ngIf="deposit.metadata.otherElectronicVersions && deposit.metadata.otherElectronicVersions.length">
               <dt class="col-sm-3" translate>Other electronic versions</dt>

--- a/projects/sonar/src/app/deposit/editor/editor.component.spec.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.spec.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { DatePipe } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -76,6 +77,7 @@ describe('EditorComponent', () => {
         ModalModule.forRoot()
       ],
       providers: [
+        DatePipe,
         { provide: ActivatedRoute, useValue: route },
         { provide: UserService, useValue: userTestingService },
         { provide: DepositService, useValue: depositTestingService }

--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -14,6 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { DatePipe } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -76,7 +77,7 @@ export class EditorComponent implements OnInit {
    * @param _dialogService Dialog service.
    * @param _userUservice User service.
    * @param _spinner Spinner service.
-   * @param _translateLanguageService Translate language service.
+   * @param _datePipe Date pipe.
    */
   constructor(
     private _toastrService: ToastrService,
@@ -88,7 +89,7 @@ export class EditorComponent implements OnInit {
     private _dialogService: DialogService,
     private _userUservice: UserService,
     private _spinner: NgxSpinnerService,
-    private _translateLanguageService: TranslateLanguageService
+    private _datePipe: DatePipe
   ) { }
 
   ngOnInit(): void {
@@ -186,6 +187,51 @@ export class EditorComponent implements OnInit {
     }
 
     return journal.join(', ');
+  }
+
+  /**
+   * Return formatted text for dissertation.
+   *
+   * @returns Text for dissertation.
+   */
+  get dissertation(): string {
+    if (!this.deposit.metadata.dissertation) {
+      return null;
+    }
+
+    const dissertation = [this.deposit.metadata.dissertation.degree];
+
+    if (
+      this.deposit.metadata.dissertation.grantingInstitution ||
+      this.deposit.metadata.dissertation.date
+    ) {
+      dissertation.push(': ');
+
+      if (this.deposit.metadata.dissertation.grantingInstitution) {
+        dissertation.push(this.deposit.metadata.dissertation.grantingInstitution);
+      }
+
+      if (this.deposit.metadata.dissertation.date) {
+        const date =
+          this.deposit.metadata.dissertation.date.length === 4
+            ? this.deposit.metadata.dissertation.date
+            : this._datePipe.transform(
+                this.deposit.metadata.dissertation.date,
+                'dd.MM.yyyy'
+              );
+        dissertation.push(`, ${date}`);
+      }
+    }
+
+    if (this.deposit.metadata.dissertation.jury_note) {
+      dissertation.push(
+        ` (${this._translateService
+          .translate('Jury note')
+          .toLowerCase()}: ${this.deposit.metadata.dissertation.jury_note})`
+      );
+    }
+
+    return dissertation.join('');
   }
 
   /**

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -95,6 +95,9 @@
         <!-- Extent -->
         <p class="my-2" *ngIf="record.extent">{{ record.extent }}</p>
 
+        <!-- Dissertation -->
+        <p class="my-2" *ngIf="record.dissertation">{{ record.dissertation.text }}</p>
+
         <!-- PART OF -->
         <div class="d-flex flex-row mb-3" *ngIf="record.partOf && record.partOf.length > 0">
           <div class="mr-1"><strong>{{ 'Published in' | translate }}:</strong></div>

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -59,9 +59,10 @@
           *ngIf="contributor.role[0] !== 'cre'">({{ ('contribution_role_' + contributor.role[0]) | translate | lowercase }})</span>
       </ng-container>
     </p>
-    <p class="mb-2 d-none d-lg-block" *ngIf="record.metadata.partOf && record.metadata.partOf.length > 0">
+    <p class="my-0 d-none d-lg-block" *ngIf="record.metadata.partOf && record.metadata.partOf.length > 0">
       {{ record.metadata.partOf[0] | publication }}</p>
-    <div class="d-none d-lg-block text-muted text-justify text-small" *ngIf="abstract">
+    <p class="my-0  d-none d-lg-block" *ngIf="record.metadata.dissertation">{{ record.metadata.dissertation.text }}</p>
+    <div class="d-none d-lg-block text-muted text-justify text-small mt-2" *ngIf="abstract">
       {{ abstract | truncateText: 30 }}
     </div>
   </div>


### PR DESCRIPTION
* Adds the dissertation field to the submission form.
* Displays dissertation text in documents brief views.
* Displays dissertation text in documents detail views.
* Displays dissertation text in deposit summary view.
* Adds `DatePipe` to providers for using it in components.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>