### PR TITLE
styles: add fonts to global CSS file.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2916,9 +2916,9 @@
       }
     },
     "@rero/ng-core": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.6.0.tgz",
-      "integrity": "sha512-USU2FCVZ3MrmJwREalpPOV4a2KPyKteBM6xNKyxpUTWXRCv9NX6v5K7EV0Gt27i2lMwr0kaasDoTrUtJwSGlgw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@rero/ng-core/-/ng-core-0.8.0.tgz",
+      "integrity": "sha512-jN0c26xq7LHGQleHW3YlEH34LdqXJ4W/Mj5q0noa5/A/1F2qI2TL3H/ZD+J2x5JlLRVv+qRtLfVKryMDmmenhg==",
       "requires": {
         "tslib": "^1.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@ngx-formly/bootstrap": "^5.7.0",
     "@ngx-formly/core": "^5.7.0",
     "@ngx-translate/core": "^12.1.1",
-    "@rero/ng-core": "^0.6.0",
+    "@rero/ng-core": "^0.8.0",
     "acorn": ">=6.4.1",
     "bootstrap": "^4.3.1",
     "crypto-js": "^3.1.9-1",

--- a/projects/sonar/src/index.html
+++ b/projects/sonar/src/index.html
@@ -7,14 +7,6 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
-    <link
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css"
-      rel="stylesheet"
-    />
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:300,700|Roboto+Condensed:300,700&display=swap"
-      rel="stylesheet"
-    />
   </head>
 
   <body>

--- a/projects/sonar/src/styles.scss
+++ b/projects/sonar/src/styles.scss
@@ -14,10 +14,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+// Font awesome
+$fa-font-path: "~font-awesome/fonts";
+
+// Bootstrap
 $font-family-base: "Roboto", sans-serif;
 $primary: #205078 !default;
 $secondary: rgb(246, 130, 17) !default;
 
+@import url('https://fonts.googleapis.com/css?family=Roboto:300,700|Roboto+Condensed:300,700');
+@import '~font-awesome/scss/font-awesome.scss';
 @import "~bootstrap/scss/bootstrap.scss";
 @import "~ngx-toastr/toastr-bs4-alert";
 


### PR DESCRIPTION
Instead of loading web fonts externally, they are included into the main Sass file of the application. By doing this, all the styles are compiled into only one file.

* Removes external HTTP call for Font Awesome font.
* Removes external HTTP call for Google's Roboto font.
* Imports both fonts in the application's styles file.
* Upgrades ng-core library to version 0.8.x.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>