### PR TITLE
organisations: enable files management

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -179,7 +179,8 @@ export class AppRoutingModule {
       {
         type: 'organisations',
         briefView: OrganisationComponent,
-        detailView: OrganisationDetailComponent
+        detailView: OrganisationDetailComponent,
+        filesEnabled: true
       },
       {
         type: 'deposits',

--- a/projects/sonar/src/app/record/organisation/detail/detail.component.html
+++ b/projects/sonar/src/app/record/organisation/detail/detail.component.html
@@ -23,6 +23,11 @@
     <dt class="col-sm-3" translate>Name</dt>
     <dd class="col-sm-9">{{ record.metadata.name }}</dd>
 
+    <ng-container *ngIf="record.metadata.description">
+      <dt class="col-sm-3" translate>Description</dt>
+      <dd class="col-sm-9" [innerHtml]="record.metadata.description | nl2br"></dd>
+    </ng-container>
+
     <dt class="col-sm-3" translate>Is shared</dt>
     <dd class="col-sm-9">
       <i class="fa fa-{{ record.metadata.isShared ? 'check' : 'close' }}"></i>

--- a/projects/sonar/src/app/record/organisation/organisation.component.html
+++ b/projects/sonar/src/app/record/organisation/organisation.component.html
@@ -14,5 +14,11 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<h4>{{ record.metadata.name }}</h4>
+
+<h4>
+  <a href="#" routerLink="{{ detailUrl.link }}">{{ record.metadata.name }}</a>
+</h4>
 <p class="mb-0"><span class="badge badge-primary">{{ record.metadata.code }}</span></p>
+<p class="mt-2" *ngIf="record.metadata.description">
+  {{ record.metadata.description | truncateText: 50 }}
+</p>


### PR DESCRIPTION
Files management is enabled for organisations for adding a logo to the organisation.

* Enables files handling for organisations.
* Displays description in the brief and detail views.
* Add a link to organisation's detail in brief views.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>