### PR TITLE
documents: display thumbnails in brief views.

### DIFF
--- a/projects/sonar/src/app/record/document/document.component.ts
+++ b/projects/sonar/src/app/record/document/document.component.ts
@@ -122,8 +122,27 @@ export class DocumentComponent implements ResultItem, OnDestroy, OnInit {
       return;
     }
 
+    // Try to find the main file. This is the first file, because files are
+    // already ordered during REST API call.
+    const mainFile = this.record.metadata._files.find(
+      (file: any) => file.type === 'file'
+    );
+
+    if (!mainFile) {
+      return;
+    }
+
+    // Find filename without extension.
+    const matches = mainFile.key.match(/^(.*)\..*$/);
+
+    if (!matches) {
+      return;
+    }
+
+    // Find thumbnail corresponding to filename.
     const thumbnail = this.record.metadata._files.find(
-      (file: any) => file.type === 'thumbnail'
+      (file: any) =>
+        file.type === 'thumbnail' && file.key === `${matches[1]}.jpg`
     );
 
     if (!thumbnail) {


### PR DESCRIPTION
This commit ensures that's the right thumbnail (corresponding to the main file) which is displayed in the brief views.

* Changes thumbnail loading method to take the thumbnail corresponding to the main file.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>