### PR TITLE
organisations: remove manual translations

### DIFF
--- a/projects/sonar/src/manual_translations.ts
+++ b/projects/sonar/src/manual_translations.ts
@@ -16,11 +16,6 @@
  */
 import { marker as _ } from '@biesbjerg/ngx-translate-extract-marker';
 
-// Organisations
-_('unifr');
-_('usi');
-_('csal');
-
 // Provision activity
 _('bf:Publication');
 _('bf:Manufacture');


### PR DESCRIPTION
Remove manual translations for organisations as the values in the facet are translated in backend

* Removes manual translations for organisations.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>