### PR TITLE
documents: display files

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -189,7 +189,7 @@ export class AppRoutingModule {
           orderList: (a: any, b: any) => {
             return a.metadata.order - b.metadata.order;
           },
-          infoExcludedFields: ['restriction', 'type'],
+          infoExcludedFields: ['restriction', 'type', 'links', 'thumbnail'],
           canUpdateMetadata: () => of({ can: true, message: '' })
         },
         searchFields: [

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -47,6 +47,7 @@ import { HttpInterceptor } from './interceptor/http.interceptor';
 import { LanguageValuePipe } from './pipe/language-value.pipe';
 import { DetailComponent as DocumentDetailComponent } from './record/document/detail/detail.component';
 import { DocumentComponent } from './record/document/document.component';
+import { FileComponent } from './record/document/file/file.component';
 import { PublicationPipe } from './record/document/publication.pipe';
 import { DetailComponent as OrganisationDetailComponent } from './record/organisation/detail/detail.component';
 import { OrganisationComponent } from './record/organisation/organisation.component';
@@ -80,7 +81,8 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     HighlightJsonPipe,
     ReviewComponent,
     AdminComponent,
-    PublicationPipe
+    PublicationPipe,
+    FileComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -18,23 +18,8 @@
   <section class="mt-3">
     <div class="row">
       <div class="col-lg-3 text-center">
-        <div class="mb-4" *ngIf="mainFile">
-          <ng-template let-thumbnail [ngTemplateOutletContext]="{ $implicit: getThumbnail(mainFile) }"
-            [ngTemplateOutlet]="t" #t>
-            <a href (click)="$event.preventDefault(); previewFileKey = mainFile.key; previewModal.show()"
-              *ngIf="thumbnail">
-              <img [src]="thumbnail" class="img-thumbnail img-fluid">
-            </a>
-          </ng-template>
-          <p class="my-1 small">{{ mainFile.label || mainFile.key }}</p>
-          <p class="m-0">
-            <a href (click)="$event.preventDefault(); previewFileKey = mainFile.key; previewModal.show()">
-              <i class="fa fa-eye mr-2"></i>
-            </a>
-            <a [href]="'/documents/' + record.pid + '/files/' + mainFile.key" target="_blank">
-              <i class="fa fa-download"></i>
-            </a>
-          </p>
+        <div class="mb-4">
+          <sonar-document-file [file]="mainFile" (previewClicked)="showPreview($event)"></sonar-document-file>
         </div>
 
         <!-- DOCUMENT TYPE -->
@@ -223,44 +208,26 @@
     <hr class="mb-4 mt-0">
     <div class="row">
       <ng-container *ngFor="let file of filteredFiles; let first = first">
-        <div class="text-center col-lg-2 mb-4" *ngIf="!first">
-          <ng-template let-thumbnail [ngTemplateOutletContext]="{ $implicit: getThumbnail(file) }"
-            [ngTemplateOutlet]="t" #t>
-            <a href (click)="$event.preventDefault(); previewFileKey = file.key; previewModal.show()" *ngIf="thumbnail">
-              <img [src]="thumbnail" class="img-thumbnail img-fluid">
-            </a>
-          </ng-template>
-          <p class="my-1 small">{{ file.label || file.key }}</p>
-          <p class="m-0">
-            <a href (click)="$event.preventDefault(); previewFileKey = file.key; previewModal.show()">
-              <i class="fa fa-eye mr-2"></i>
-            </a>
-            <a [href]="'/documents/' + record.pid + '/files/' + file.key" target="_blank">
-              <i class="fa fa-download"></i>
-            </a>
-          </p>
+        <div class="col-lg-2 mb-5" *ngIf="!first">
+          <sonar-document-file [file]="file" (previewClicked)="showPreview($event)"></sonar-document-file>
         </div>
       </ng-container>
     </div>
   </ng-container>
 
   <!--Preview modal-->
-  <div bsModal #previewModal="bs-modal" class="modal fade" tabindex="-1" role="dialog"
-    aria-labelledby="dialog-sizes-name1">
-    <div class="modal-dialog modal-lg">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 id="dialog-sizes-name1" class="modal-title pull-left">{{ previewFileKey }}</h4>
-          <button type="button" class="close pull-right" (click)="previewModal.hide()" aria-label="Close">
-            <span aria-hidden="true">&times;</span>
-          </button>
-        </div>
-        <div class="modal-body">
-          <iframe class="preview-iframe" id="preview-iframe" width="100%" height="500"
-            [src]="previewFileKey | fileLink: 'documents':record.pid:'preview'" style="border: none;"
-            *ngIf="previewFileKey"></iframe>
-        </div>
+  <ng-template #previewModal>
+    <ng-container *ngIf="previewFile">
+      <div class="modal-header">
+        <h4 id="dialog-sizes-name1" class="modal-title pull-left">{{ previewFile.label }}</h4>
+        <button type="button" class="close pull-right" aria-label="Close" (click)="previewModalRef.hide()">
+          <span aria-hidden="true">&times;</span>
+        </button>
       </div>
-    </div>
-  </div>
+      <div class="modal-body">
+        <iframe class="preview-iframe" id="preview-iframe" width="100%" height="500" [src]="previewFile.url"
+          style="border: none;"></iframe>
+      </div>
+    </ng-container>
+  </ng-template>
 </ng-container>

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -16,23 +16,7 @@
 -->
 <div class="row">
   <div class="col-2 d-none d-lg-block text-center">
-    <ng-container *ngIf="thumbnail">
-      <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
-        <img [src]="thumbnail" class="img-thumbnail img-fluid p-2"
-          [alt]="record.metadata.title[0].mainTitle | languageValue">
-      </a>
-      <ng-template #routingLink>
-        <a [routerLink]="detailUrl.link">
-          <img [src]="thumbnail" class="img-thumbnail img-fluid"
-            [alt]="record.metadata.title[0].mainTitle | languageValue">
-        </a>
-      </ng-template>
-      <p class="my-2" *ngIf="embargoDate">
-        <span class="badge badge-secondary text-light">
-          {{ 'Public access from' | translate }}<br>{{ embargoDate | date:'dd/MM/yyyy' }}
-        </span>
-      </p>
-    </ng-container>
+    <sonar-document-file [file]="mainFile" [showLabel]="false" [showPreview]="false" [showDownload]="false" [showExternalLink]="false" [link]="detailUrl.link" [inRouter]="!detailUrl.external"></sonar-document-file>
     <p class="my-2" *ngIf="record.metadata.documentType">
       <small>{{ ('document_type_' + record.metadata.documentType) | translate }}</small>
     </p>

--- a/projects/sonar/src/app/record/document/document.interface.ts
+++ b/projects/sonar/src/app/record/document/document.interface.ts
@@ -1,0 +1,30 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+export interface DocumentFile {
+  key: string;
+  label: string;
+  thumbnail: string;
+  links: {
+    external: string;
+    preview: string;
+    download: string;
+  };
+  restriction: {
+    restricted: boolean;
+    date: string;
+  };
+}

--- a/projects/sonar/src/app/record/document/file/file.component.html
+++ b/projects/sonar/src/app/record/document/file/file.component.html
@@ -1,0 +1,75 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<div class="text-center">
+  <ng-container *ngIf="file; else noFile">
+    <ng-container *ngIf="link; else previewOrExternal">
+      <a [routerLink]="link" *ngIf="inRouter; else normalLink">
+        <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+      </a>
+      <ng-template #normalLink>
+        <a [href]="link">
+          <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+        </a>
+      </ng-template>
+    </ng-container>
+    <ng-template #previewOrExternal>
+      <ng-container *ngIf="showExternalLink && file.links.external; else previewLink">
+        <a href="{{ file.links.external }}" target="_blank">
+          <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+        </a>
+      </ng-container>
+      <ng-template #previewLink>
+        <ng-container *ngIf="showPreview && file.links.preview; else downloadLink">
+          <a href="{{ file.links.preview }}" (click)="preview(file); $event.preventDefault()">
+            <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+          </a>
+        </ng-container>
+        <ng-template #downloadLink>
+          <ng-container *ngIf="showDownload && file.links.download; else noLink">
+            <a href="{{ file.links.download }}?download" *ngIf="showDownload && file.links.download">
+              <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+            </a>
+          </ng-container>
+          <ng-template #noLink>
+            <img src="{{ file.thumbnail }}" class="img-fluid" alt="{{ file.label }}">
+          </ng-template>
+        </ng-template>
+      </ng-template>
+    </ng-template>
+    <div class="my-1 small" *ngIf="showLabel">{{ file.label }}</div>
+    <div class="my-1">
+      <span class="badge badge-secondary text-light" *ngIf="file.restriction && file.restriction.date">
+        {{ 'Public access from' | translate }}<br>{{ file.restriction.date }}
+      </span>
+    </div>
+    <div class="my-1">
+      <a href="{{ file.links.external }}" target="_blank" *ngIf="showExternalLink && file.links.external">
+        <i class="fa fa-external-link mx-1"></i>
+      </a>
+      <a href="{{ file.links.preview }}" *ngIf="showPreview && file.links.preview"
+        (click)="preview(file); $event.preventDefault()">
+        <i class="fa fa-eye mx-1"></i>
+      </a>
+      <a href="{{ file.links.download }}?download" *ngIf="showDownload && file.links.download">
+        <i class="fa fa-download mx-1"></i>
+      </a>
+    </div>
+  </ng-container>
+  <ng-template #noFile>
+    <img src="/static/images/no-image.png" class="img-fluid">
+  </ng-template>
+</div>

--- a/projects/sonar/src/app/record/document/file/file.component.spec.ts
+++ b/projects/sonar/src/app/record/document/file/file.component.spec.ts
@@ -1,0 +1,57 @@
+import { HttpClientModule } from '@angular/common/http';
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  TranslateLoader as BaseTranslateLoader,
+  TranslateModule
+} from '@ngx-translate/core';
+import { RecordModule, TranslateLoader } from '@rero/ng-core';
+import { FileComponent } from './file.component';
+
+describe('FileComponent', () => {
+  let component: FileComponent;
+  let fixture: ComponentFixture<FileComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [FileComponent],
+      imports: [
+        HttpClientModule,
+        RouterTestingModule,
+        TranslateModule.forRoot({
+          loader: {
+            provide: BaseTranslateLoader,
+            useClass: TranslateLoader,
+          },
+        }),
+        RecordModule,
+      ],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/sonar/src/app/record/document/file/file.component.ts
+++ b/projects/sonar/src/app/record/document/file/file.component.ts
@@ -1,0 +1,64 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { DocumentFile } from '../document.interface';
+
+@Component({
+  selector: 'sonar-document-file',
+  templateUrl: './file.component.html'
+})
+export class FileComponent {
+  // File object.
+  @Input()
+  file: DocumentFile;
+
+  // Show preview icon
+  @Input()
+  showPreview = true;
+
+  // Show download icon
+  @Input()
+  showDownload = true;
+
+  @Input()
+  showExternalLink = true;
+
+  // Show label
+  @Input()
+  showLabel = true;
+
+  // Force link.
+  @Input()
+  link: string;
+
+  // In router or standard href link
+  @Input()
+  inRouter = false;
+
+  /** Event emitted when a preview is clicked. */
+  @Output()
+  previewClicked: EventEmitter<any> = new EventEmitter();
+
+  /**
+   * Method called when a preview link is clicked.
+   *
+   * @param file Document file object.
+   */
+  preview(file: DocumentFile): void {
+    this.previewClicked.emit(file);
+  }
+}


### PR DESCRIPTION
This PR aims to display files of several types. It refactors the way to display files as with the old manner, only PDF files were well displayed.

* Hides `links` and `thumbnail` data in the file information.
* Adds a document file component to display files.
* Uses the new component to display files in brief and detail views.
* Removes useless code for files in brief and detail components.
* Adds an interface to represent a document file.
* Displays modal preview programmitically, as the action is sent by an output emitter.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>