### PR TITLE
deposit: add license

### DIFF
--- a/projects/sonar/src/app/core/step/step.component.html
+++ b/projects/sonar/src/app/core/step/step.component.html
@@ -36,6 +36,7 @@
           [routerLink]="[linkPrefix, step]"
           *ngIf="i <= maxStepIndex; else noLink"
           [ngClass]="{ 'text-light': i <= currentStepIndex }"
+          (click)="click(step)"
         >
           <ng-container
             *ngTemplateOutlet="

--- a/projects/sonar/src/app/core/step/step.component.ts
+++ b/projects/sonar/src/app/core/step/step.component.ts
@@ -42,6 +42,10 @@ export class StepComponent implements OnInit {
   @Output()
   cancel: EventEmitter<any> = new EventEmitter();
 
+  /** Event emitted when a step is clicked. */
+  @Output()
+  clicked: EventEmitter<any> = new EventEmitter();
+
   ngOnInit() {
     if (this.steps.length === 0) {
       throw new Error('No steps defined');
@@ -82,5 +86,14 @@ export class StepComponent implements OnInit {
   doCancel(event: Event) {
     event.preventDefault();
     this.cancel.emit();
+  }
+
+  /**
+   * Method triggered when a step is clicked.
+   *
+   * @param step Step clicked.
+   */
+  click(step: string) {
+    this.clicked.emit(step);
   }
 }

--- a/projects/sonar/src/app/deposit/editor/editor.component.html
+++ b/projects/sonar/src/app/deposit/editor/editor.component.html
@@ -16,17 +16,17 @@
 -->
 <ng-container *ngIf="deposit">
   <sonar-deposit-step [currentStep]="currentStep" [maxStep]="maxStep" [linkPrefix]="linkPrefix" [steps]="steps"
-    (cancel)="cancelDeposit()">
+    (cancel)="cancelDeposit()" (clicked)="view = 'form'">
   </sonar-deposit-step>
 
   <sonar-deposit-review [deposit]="deposit" *ngIf="currentStep === 'diffusion'"></sonar-deposit-review>
 </ng-container>
 
 <ng-container *ngIf="deposit">
-  <form [formGroup]="form" (ngSubmit)="save()">
+  <form [formGroup]="form">
     <div class="row">
       <div class="col-sm-8">
-        <ng-container *ngIf="view === 'form' && currentStep !== 'diffusion'">
+        <ng-container *ngIf="view === 'form'">
           <div class="row mb-4">
             <div class="col-6">
               <div class="btn-group" dropdown *ngIf="currentStep === 'metadata' && mainFile">
@@ -44,9 +44,17 @@
               </div>
             </div>
             <div class="col-6 text-right">
-              <button type="submit" class="btn btn-primary" *ngIf="isFinished() === false">
+              <button type="submit" class="btn btn-primary" (click)="save()">
                 <i class="fa fa-floppy-o mr-2"></i>
                 {{ 'Save' | translate }}
+              </button>
+              <button type="submit" class="btn btn-primary ml-2 pull-right" (click)="publish()"
+                *ngIf="canSubmit()">
+                <i class="fa fa-check mr-2"></i>
+                <span *ngIf="isAdminUser; else submitLabel">
+                  {{ 'Publish' | translate }}
+                </span>
+                <ng-template #submitLabel>{{ 'Submit' | translate }}</ng-template>
               </button>
             </div>
           </div>
@@ -59,15 +67,6 @@
         </ng-container>
 
         <ng-container *ngIf="showPreview && deposit.metadata">
-          <button type="button" class="btn btn-primary ml-2 pull-right" (click)="publish()"
-            *ngIf="isFinished() === true">
-            <i class="fa fa-check mr-2"></i>
-            <span *ngIf="isAdminUser; else submitLabel">
-              {{ 'Publish' | translate }}
-            </span>
-            <ng-template #submitLabel>{{ 'Submit' | translate }}</ng-template>
-          </button>
-
           <h3 class="mb-2">{{ deposit.metadata.title }}</h3>
           <p class="m-0">
             <strong></strong>
@@ -118,7 +117,7 @@
               </dd>
             </ng-container>
 
-            <ng-container *ngIf="deposit.metadata.identifiedBy">
+            <ng-container *ngIf="deposit.metadata.identifiedBy && deposit.metadata.identifiedBy.length">
               <dt class="col-sm-3" translate>Identifiers</dt>
               <dd class="col-sm-9">
                 <p class="m-0" *ngFor="let identifier of deposit.metadata.identifiedBy">
@@ -144,7 +143,7 @@
               </dd>
             </ng-container>
 
-            <ng-container *ngIf="deposit.metadata.dissertation">
+            <ng-container *ngIf="deposit.metadata.dissertation && deposit.metadata.dissertation.degree">
               <dt class="col-sm-3" translate>Dissertation</dt>
               <dd class="col-sm-9">
                 {{ dissertation }}

--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -91,7 +91,7 @@ export class EditorComponent implements OnInit {
     private _userUservice: UserService,
     private _spinner: NgxSpinnerService,
     private _datePipe: DatePipe
-  ) { }
+  ) {}
 
   ngOnInit(): void {
     this._route.params
@@ -179,25 +179,28 @@ export class EditorComponent implements OnInit {
 
     if (this.deposit.metadata.publication.volume) {
       journal.push(
-        this._translateService.translate('vol.') +
-        ' ' +
-        this.deposit.metadata.publication.volume
+        [
+          this._translateService.translate('vol.'),
+          this.deposit.metadata.publication.volume,
+        ].join(' ')
       );
     }
 
     if (this.deposit.metadata.publication.number) {
       journal.push(
-        this._translateService.translate('no.') +
-        ' ' +
-        this.deposit.metadata.publication.number
+        [
+          this._translateService.translate('no.'),
+          this.deposit.metadata.publication.number,
+        ].join(' ')
       );
     }
 
     if (this.deposit.metadata.publication.pages) {
       journal.push(
-        this._translateService.translate('p.') +
-        ' ' +
-        this.deposit.metadata.publication.pages
+        [
+          this._translateService.translate('p.'),
+          this.deposit.metadata.publication.pages,
+        ].join(' ')
       );
     }
 
@@ -233,9 +236,9 @@ export class EditorComponent implements OnInit {
           this.deposit.metadata.dissertation.date.length === 4
             ? this.deposit.metadata.dissertation.date
             : this._datePipe.transform(
-              this.deposit.metadata.dissertation.date,
-              'dd.MM.yyyy'
-            );
+                this.deposit.metadata.dissertation.date,
+                'dd.MM.yyyy'
+              );
         dissertation.push(`, ${date}`);
       }
     }
@@ -243,7 +246,7 @@ export class EditorComponent implements OnInit {
     if (this.deposit.metadata.dissertation.jury_note) {
       dissertation.push(
         ` (${this._translateService.translate('Jury note').toLowerCase()}: ${
-        this.deposit.metadata.dissertation.jury_note
+          this.deposit.metadata.dissertation.jury_note
         })`
       );
     }
@@ -314,12 +317,12 @@ export class EditorComponent implements OnInit {
   /**
    * Return if the form is ready to publish or not.
    */
-  isFinished(): boolean {
+  canSubmit(): boolean {
     return (
       (this.deposit.status === 'in_progress' ||
         this.deposit.status === 'ask_for_changes') &&
-      this.currentStep === this.steps[this.steps.length - 1] &&
-      this.deposit.step === this.steps[this.steps.length - 1]
+      this.currentStep === 'diffusion' &&
+      this.deposit.diffusion
     );
   }
 
@@ -489,7 +492,8 @@ export class EditorComponent implements OnInit {
 
           // expression properties
           if (fieldSchema.form.expressionProperties) {
-            fieldConfig.expressionProperties = fieldSchema.form.expressionProperties;
+            fieldConfig.expressionProperties =
+              fieldSchema.form.expressionProperties;
           }
 
           // hide expression

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -17,8 +17,8 @@
 <ng-container *ngIf="record">
   <section class="mt-3">
     <div class="row">
-      <div class="col-lg-3">
-        <div class="mb-4 text-center" *ngIf="mainFile">
+      <div class="col-lg-3 text-center">
+        <div class="mb-4" *ngIf="mainFile">
           <ng-template let-thumbnail [ngTemplateOutletContext]="{ $implicit: getThumbnail(mainFile) }"
             [ngTemplateOutlet]="t" #t>
             <a href (click)="$event.preventDefault(); previewFileKey = mainFile.key; previewModal.show()"
@@ -38,11 +38,11 @@
         </div>
 
         <!-- DOCUMENT TYPE -->
-        <h5 class="text-center my-4" *ngIf="record.documentType">
+        <h5 class="my-4" *ngIf="record.documentType">
           {{ ('document_type_' + record.documentType) | translate }}
         </h5>
 
-        <p class="text-center" *ngIf="filteredFiles.length > 1">
+        <p *ngIf="filteredFiles.length > 1">
           <a href="#" (click)="goToOtherFile($event, 'other-files')">+ {{ filteredFiles.length-1 }}
             {{ 'other files' | translate }}</a>
         </p>
@@ -193,6 +193,17 @@
             <dd class="col-lg-8">
               <ng-container *ngFor="let classification of record.classification">
                 {{ ('classification_' + classification.classificationPortion) | translate }}
+              </ng-container>
+            </dd>
+          </ng-container>
+
+          <!-- LICENSE -->
+          <ng-container *ngIf="record.usageAndAccessPolicy">
+            <dt class="col-lg-4" translate>License</dt>
+            <dd class="col-lg-8">
+              {{ record.usageAndAccessPolicy.license | translate }}
+              <ng-container *ngIf="record.usageAndAccessPolicy.label">
+                <br>{{ record.usageAndAccessPolicy.label }}
               </ng-container>
             </dd>
           </ng-container>

--- a/projects/sonar/src/manual_translations.ts
+++ b/projects/sonar/src/manual_translations.ts
@@ -223,3 +223,14 @@ _('uri');
 _('bf:ReportNumber');
 _('bf:Strn');
 _('pmid');
+
+// Licenses
+_('CC0');
+_('CC BY');
+_('CC BY-NC');
+_('CC BY-NC-ND');
+_('CC BY-NC-SA');
+_('CC BY-ND');
+_('CC BY-SA');
+_('Other OA / license undefined');
+_('Not OA / Rights reserved');


### PR DESCRIPTION
This commit adds a license field in the last step of deposit process. The license is displayed in the document's detail view.

* Displays the license field in the `diffusion` step of deposit process.
* Emits an event when a step is clicked, for resetting the current view to `form` when the user changes the step.
* Displays the submit button only if the license has been saved.
* Fixes the display of `identifiedBy` and `dissertation` fields in preview.
* Displays the license in document's detail view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>