### PR TITLE
documents: enable editor long mode

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -178,7 +178,9 @@ export class AppRoutingModule {
           'subject',
           'organisation',
         ],
-        editorLongMode: true,
+        editorSettings: {
+          longMode: true
+        },
         files: {
           enabled: true,
           filterList: (item: any) => {
@@ -238,7 +240,7 @@ export class AppRoutingModule {
               key: config.type,
               label: config.type.charAt(0).toUpperCase() + config.type.slice(1),
               component: config.briefView || null,
-              editorLongMode: config.editorLongMode || false,
+              editorSettings: config.editorSettings || false,
               detailComponent: config.detailView || null,
               aggregations: config.aggregations || null,
               aggregationsExpand: config.aggregationsExpand || [],


### PR DESCRIPTION
* Enables long mode fore documents editor as it's no more enabled by default.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>
