### PR TITLE
deposits: add project step

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -34,6 +34,9 @@
             <li class="nav-item" *ngIf="user.is_moderator">
               <a class="nav-link" routerLink="/records/documents" translate>Documents</a>
             </li>
+            <li class="nav-item" *ngIf="user.is_submitter">
+              <a class="nav-link" routerLink="/records/projects" translate>Projects</a>
+            </li>
             <li class="nav-item dropdown" *ngIf="user.is_submitter" dropdown>
               <a class="nav-link dropdown-toggle" role="button" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false" dropdownToggle translate>

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -33,6 +33,8 @@ import { DetailComponent as DocumentDetailComponent } from './record/document/de
 import { DocumentComponent } from './record/document/document.component';
 import { DetailComponent as OrganisationDetailComponent } from './record/organisation/detail/detail.component';
 import { OrganisationComponent } from './record/organisation/organisation.component';
+import { BriefViewComponent as ProjectBriefViewComponent } from './record/project/brief-view/brief-view.component';
+import { DetailComponent as ProjectDetailComponent } from './record/project/detail/detail.component';
 import { DetailComponent as UserDetailComponent } from './record/user/detail/detail.component';
 import { UserComponent } from './record/user/user.component';
 import { UserService } from './user.service';
@@ -219,6 +221,16 @@ export class AppRoutingModule {
         aggregations: AggregationFilter.filter,
         aggregationsExpand: ['status', 'user', 'contributor'],
         aggregationsOrder: ['status', 'user', 'contributor']
+      },
+      {
+        type: 'projects',
+        briefView: ProjectBriefViewComponent,
+        detailView: ProjectDetailComponent,
+        editorSettings: {
+          longMode: true
+        },
+        aggregationsExpand: ['organisation', 'user'],
+        aggregationsOrder: ['organisation', 'user']
       }
     ];
 

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -51,9 +51,12 @@ import { FileComponent } from './record/document/file/file.component';
 import { PublicationPipe } from './record/document/publication.pipe';
 import { DetailComponent as OrganisationDetailComponent } from './record/organisation/detail/detail.component';
 import { OrganisationComponent } from './record/organisation/organisation.component';
+import { BriefViewComponent as ProjectBriefViewComponent } from './record/project/brief-view/brief-view.component';
+import { DetailComponent as ProjectDetailComponent } from './record/project/detail/detail.component';
 import { DetailComponent as UserDetailComponent } from './record/user/detail/detail.component';
 import { UserComponent } from './record/user/user.component';
 import { AdminComponent } from './_layout/admin/admin.component';
+import { IdentifierComponent } from './record/identifier/identifier.component';
 
 export function minElementError(err: any, field: FormlyFieldConfig) {
   return `This field must contain at least ${field.templateOptions.minItems} element.`;
@@ -82,7 +85,10 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     ReviewComponent,
     AdminComponent,
     PublicationPipe,
-    FileComponent
+    FileComponent,
+    ProjectBriefViewComponent,
+    ProjectDetailComponent,
+    IdentifierComponent
   ],
   imports: [
     BrowserModule,
@@ -125,7 +131,9 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     DocumentDetailComponent,
     OrganisationDetailComponent,
     UserDetailComponent,
-    BriefViewComponent
+    BriefViewComponent,
+    ProjectBriefViewComponent,
+    ProjectDetailComponent
   ],
   bootstrap: [AppComponent]
 })

--- a/projects/sonar/src/app/deposit/editor/editor.component.html
+++ b/projects/sonar/src/app/deposit/editor/editor.component.html
@@ -48,8 +48,7 @@
                 <i class="fa fa-floppy-o mr-2"></i>
                 {{ 'Save' | translate }}
               </button>
-              <button type="submit" class="btn btn-primary ml-2 pull-right" (click)="publish()"
-                *ngIf="canSubmit()">
+              <button type="submit" class="btn btn-primary ml-2 pull-right" (click)="publish()" *ngIf="canSubmit()">
                 <i class="fa fa-check mr-2"></i>
                 <span *ngIf="isAdminUser; else submitLabel">
                   {{ 'Publish' | translate }}
@@ -203,6 +202,54 @@
                   <span class="badge badge-secondary text-light ml-1" *ngIf="author.orcid">{{ author.orcid }}</span>
                   <small class="text-muted ml-1" *ngIf="author.affiliation"><i>{{ author.affiliation }}</i></small>
                 </p>
+              </dd>
+            </ng-container>
+
+            <ng-container *ngIf="deposit.projects">
+              <dt class="col-sm-3" translate>Projects</dt>
+              <dd class="col-sm-9">
+                <ul class="list-group list-group-flush">
+                  <li class="list-group-item py-1 pl-0" *ngFor="let project of deposit.projects">
+                    <ng-container *ngIf="project.$ref; else fullProject">
+                      <ng-container *ngIf="project.$ref | getRecord: 'projects' | async as savedProject">
+                        {{ savedProject.metadata.name }}
+                        <span class="badge badge-secondary text-light ml-2" translate>Existing project</span>
+                      </ng-container>
+                    </ng-container>
+                    <ng-template #fullProject>
+                      {{ project.name }}
+                      <ng-container *ngIf="project.identifier">
+                        <span class="badge badge-secondary text-light mx-2">{{ project.identifier }}</span>
+                      </ng-container>
+                      <small>{{ project.startDate }}{{ project.endDate ? ' - ' + project.endDate : '' }}</small>
+                      <ng-container *ngIf="project.description">
+                        <br><small [innerHtml]="project.description | nl2br"></small>
+                      </ng-container>
+                      <ng-container *ngIf="project.investigators">
+                        <br>{{ 'Investigators' | translate }}:
+                        <small>
+                          <ng-container *ngFor="let investigator of project.investigators">
+                            <br>
+                            {{ investigator.name }}
+                            <span class="badge badge-secondary text-light ml-1">{{ investigator.role | translate }}</span>
+                            <span class="badge badge-secondary text-light ml-1" *ngIf="investigator.affiliation">{{ investigator.affiliation }}</span>
+                            <span class="badge badge-secondary text-light ml-1" *ngIf="investigator.orcid">{{ investigator.orcid }}</span>
+                          </ng-container>
+                        </small>
+                      </ng-container>
+                      <ng-container *ngIf="project.funding_organisations">
+                        <br>{{ 'Funding organsations' | translate }}:
+                        <small>
+                          <ng-container *ngFor="let funding_organisation of project.funding_organisations">
+                            <br>
+                            {{ funding_organisation.name }}
+                            <span class="badge badge-secondary text-light ml-1" *ngIf="funding_organisation.identifier">{{ funding_organisation.identifier }}</span>
+                          </ng-container>
+                        </small>
+                      </ng-container>
+                    </ng-template>
+                  </li>
+                </ul>
               </dd>
             </ng-container>
           </dl>

--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -46,7 +46,13 @@ export class EditorComponent implements OnInit {
   currentStep = 'metadata';
 
   /** Deposit steps */
-  steps: string[] = ['create', 'metadata', 'contributors', 'diffusion'];
+  steps: string[] = [
+    'create',
+    'metadata',
+    'contributors',
+    'projects',
+    'diffusion',
+  ];
 
   /** Form for current type */
   form: FormGroup = new FormGroup({});
@@ -468,6 +474,9 @@ export class EditorComponent implements OnInit {
   private createForm(schema: any) {
     const depositFields = this._formlyJsonschema.toFieldConfig(schema, {
       map: (fieldConfig: any, fieldSchema: any) => {
+        // Force long mode to be able to remove fields.
+        fieldConfig.templateOptions.longMode = true;
+
         if (fieldSchema.form) {
           // Template options
           if (fieldSchema.form.templateOptions) {
@@ -499,6 +508,17 @@ export class EditorComponent implements OnInit {
           // hide expression
           if (fieldSchema.form.hideExpression) {
             fieldConfig.hideExpression = fieldSchema.form.hideExpression;
+          }
+
+          if (
+            fieldSchema.form.remoteTypeahead &&
+            fieldSchema.form.remoteTypeahead.type
+          ) {
+            fieldConfig.type = 'remoteTypeahead';
+            fieldConfig.templateOptions = {
+              ...fieldConfig.templateOptions,
+              ...{ remoteTypeahead: fieldSchema.form.remoteTypeahead },
+            };
           }
         }
 

--- a/projects/sonar/src/app/deposit/upload/upload.component.html
+++ b/projects/sonar/src/app/deposit/upload/upload.component.html
@@ -18,7 +18,7 @@
   [currentStep]="'create'"
   [maxStep]="maxStep"
   [linkPrefix]="linkPrefix"
-  [steps]="['create', 'metadata', 'contributors', 'diffusion']"
+  [steps]="['create', 'metadata', 'contributors', 'projects', 'diffusion']"
   (cancel)="cancelDeposit()"
 >
 </sonar-deposit-step>

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -129,12 +129,24 @@
         </div>
 
         <dl class="row mb-0">
+          <!-- PROJECTS -->
+          <ng-container *ngIf="record.projects">
+            <dt class="col-lg-4" translate>Linked projects</dt>
+            <dd class="col-lg-8">
+              <ul class="list-unstyled mb-0">
+                <li class="p-0" *ngFor="let project of record.projects">
+                  <a [routerLink]="['/', 'records', 'projects', 'detail', project.pid]">{{ project.name }}</a>
+                </li>
+              </ul>
+            </dd>
+          </ng-container>
+
           <!-- OTHER EDITION -->
           <ng-container *ngIf="record.otherEdition">
             <dt class="col-lg-4" translate>
               Other electronic version
             </dt>
-            <dd class="col-lg-6">
+            <dd class="col-lg-8">
               <p class="m-0" *ngFor="let otherEdition of record.otherEdition">
                 {{ otherEdition.publicNote }} : <a [href]="otherEdition.document.electronicLocator"
                   target="_blank">{{ otherEdition.document.electronicLocator }}</a>

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -44,10 +44,10 @@
             <ng-container *ngFor="let contributor of filteredContributors">
               <li>
                 {{ contributor.text }}
-                <a [href]="'https://orcid.org/' + contributor.agent.identifiedBy.value" target="_blank"
-                  class="badge badge-secondary text-light mx-1" *ngIf="contributor.agent.identifiedBy">
-                  ORCID
-                </a>
+                <sonar-record-identifier [type]="contributor.agent.identifiedBy.type"
+                  [value]="contributor.agent.identifiedBy.value" [source]="contributor.agent.identifiedBy.source"
+                  *ngIf="contributor.agent.identifiedBy">
+                </sonar-record-identifier>
                 <ng-container *ngIf="contributor.affiliation">
                   <small class="ml-1" *ngIf="contributor.controlledAffiliation; else affiliation"
                     [tooltip]="contributor.controlledAffiliation | join:' ; '">
@@ -161,13 +161,9 @@
             </dt>
             <dd class="col-lg-6">
               <p class="m-0" *ngFor="let identifier of record.identifiedBy">
-                <span class="badge badge-secondary text-light mr-1">
-                  {{ identifier.type | translate }}
-                </span>
-                {{ identifier.value }}
-                <i class="text-muted ml-1" *ngIf="identifier.source">
-                  {{ identifier.source }}
-                </i>
+                <sonar-record-identifier [type]="identifier.type" [value]="identifier.value"
+                  [source]="identifier.source">
+                </sonar-record-identifier>
               </p>
             </dd>
           </ng-container>

--- a/projects/sonar/src/app/record/identifier/identifier.component.html
+++ b/projects/sonar/src/app/record/identifier/identifier.component.html
@@ -1,0 +1,28 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<ng-container *ngIf="isSourceOrcid === false; else orcid">
+  <span class="badge badge-secondary text-light mr-1">
+    {{ badgeValue }}
+  </span>
+  {{ value }}
+</ng-container>
+<ng-template #orcid>
+  <a [href]="'https://orcid.org/' + value" target="_blank" class="badge badge-secondary text-light mx-1">
+    ORCID
+  </a>
+</ng-template>

--- a/projects/sonar/src/app/record/identifier/identifier.component.spec.ts
+++ b/projects/sonar/src/app/record/identifier/identifier.component.spec.ts
@@ -1,0 +1,54 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { HttpClientModule } from '@angular/common/http';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { RecordModule, TranslateLoader } from '@rero/ng-core';
+import { IdentifierComponent } from './identifier.component';
+
+describe('IdentifierComponent', () => {
+  let component: IdentifierComponent;
+  let fixture: ComponentFixture<IdentifierComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ IdentifierComponent ],
+      imports: [
+        TranslateModule.forRoot({
+          loader: {
+            provide: BaseTranslateLoader,
+            useClass: TranslateLoader
+          }
+        }),
+        HttpClientModule,
+        RecordModule
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(IdentifierComponent);
+    component = fixture.componentInstance;
+    component.type = 'bf:Local';
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/sonar/src/app/record/identifier/identifier.component.ts
+++ b/projects/sonar/src/app/record/identifier/identifier.component.ts
@@ -1,0 +1,67 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, Input } from '@angular/core';
+import { TranslateService } from '@rero/ng-core';
+
+@Component({
+  selector: 'sonar-record-identifier',
+  templateUrl: './identifier.component.html',
+})
+export class IdentifierComponent {
+  @Input()
+  type: string;
+
+  @Input()
+  value: string;
+
+  @Input()
+  source: string;
+
+  /**
+   * Constructor.
+   *
+   * @param _translateService: Translate service.
+   */
+  constructor(private _translateService: TranslateService) {}
+
+  /**
+   * Return the value to display in the badge
+   *
+   * @returns String value displayed in the badge
+   */
+  get badgeValue(): string {
+    if (this.type == null) {
+      throw new Error('Type cannot not be empty');
+    }
+
+    return this.type === 'bf:Local'
+      ? this.source
+      : this._translateService.translate(this.type);
+  }
+
+  /**
+   * Check if source is set to ORCID.
+   *
+   * @returns True if source is set to ORCID.
+   */
+  get isSourceOrcid(): boolean {
+    if (this.source == null) {
+      return false;
+    }
+    return this.source.toLowerCase() === 'orcid';
+  }
+}

--- a/projects/sonar/src/app/record/project/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/record/project/brief-view/brief-view.component.html
@@ -1,0 +1,21 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<h4>
+  <a href="#" routerLink="{{ detailUrl.link }}">{{ record.metadata.name }}</a>
+</h4>
+<p class="mb-0"><span class="badge badge-primary">{{ record.metadata.organisation.name }}</span></p>

--- a/projects/sonar/src/app/record/project/brief-view/brief-view.component.ts
+++ b/projects/sonar/src/app/record/project/brief-view/brief-view.component.ts
@@ -1,0 +1,32 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component } from '@angular/core';
+import { ResultItem } from '@rero/ng-core';
+
+@Component({
+  templateUrl: './brief-view.component.html'
+})
+export class BriefViewComponent implements ResultItem {
+  // Record data.
+  record: any;
+
+  // Resource type.
+  type: string;
+
+  // Detail URL object.
+  detailUrl: { link: string, external: boolean };
+}

--- a/projects/sonar/src/app/record/project/detail/detail.component.html
+++ b/projects/sonar/src/app/record/project/detail/detail.component.html
@@ -38,48 +38,52 @@
       </dd>
     </ng-container>
 
-    <dt class="col-sm-3" translate>Investigators</dt>
-    <dd class="col-sm-9">
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item px-0 py-1" *ngFor="let investigator of record.metadata.investigators">
-          {{ investigator.agent.preferred_name }}<span class="badge badge-secondary text-light ml-1"
-            *ngFor="let role of investigator.role">{{ role | translate  }}</span>
-          <dl class="row mb-0" *ngIf="investigator.affiliation || investigator.identifiedBy">
-            <ng-container *ngIf="investigator.affiliation">
-              <dt class="col-sm-2" translate>Affiliation</dt>
-              <dd class="col-sm-10 mb-0">{{ investigator.affiliation }}</dd>
-            </ng-container>
+    <ng-container *ngIf="record.metadata.investigators">
+      <dt class="col-sm-3" translate>Investigators</dt>
+      <dd class="col-sm-9">
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item px-0 py-1" *ngFor="let investigator of record.metadata.investigators">
+            {{ investigator.agent.preferred_name }}<span class="badge badge-secondary text-light ml-1"
+              *ngFor="let role of investigator.role">{{ role | translate  }}</span>
+            <dl class="row mb-0" *ngIf="investigator.affiliation || investigator.identifiedBy">
+              <ng-container *ngIf="investigator.affiliation">
+                <dt class="col-sm-2" translate>Affiliation</dt>
+                <dd class="col-sm-10 mb-0">{{ investigator.affiliation }}</dd>
+              </ng-container>
 
-            <ng-container *ngIf="investigator.identifiedBy">
+              <ng-container *ngIf="investigator.identifiedBy">
+                <dt class="col-sm-2" translate>Identifier</dt>
+                <dd class="col-sm-10">
+                  <sonar-record-identifier [type]="investigator.identifiedBy.type"
+                    [value]="investigator.identifiedBy.value" [source]="investigator.identifiedBy.source">
+                  </sonar-record-identifier>
+                </dd>
+              </ng-container>
+            </dl>
+          </li>
+        </ul>
+      </dd>
+    </ng-container>
+
+    <ng-container *ngIf="record.metadata.funding_organisations">
+      <dt class="col-sm-3" translate>Funding organisations</dt>
+      <dd class="col-sm-9">
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item px-0 py-1"
+            *ngFor="let funding_organisation of record.metadata.funding_organisations">
+            {{ funding_organisation.agent.preferred_name }}
+            <dl class="row mb-0" *ngIf="funding_organisation.identifiedBy">
               <dt class="col-sm-2" translate>Identifier</dt>
               <dd class="col-sm-10">
-                <sonar-record-identifier [type]="investigator.identifiedBy.type"
-                  [value]="investigator.identifiedBy.value" [source]="investigator.identifiedBy.source">
+                <sonar-record-identifier [type]="funding_organisation.identifiedBy.type"
+                  [value]="funding_organisation.identifiedBy.value" [source]="funding_organisation.identifiedBy.source">
                 </sonar-record-identifier>
               </dd>
-            </ng-container>
-          </dl>
-        </li>
-      </ul>
-    </dd>
-
-    <dt class="col-sm-3" translate>Funding organisations</dt>
-    <dd class="col-sm-9">
-      <ul class="list-group list-group-flush">
-        <li class="list-group-item px-0 py-1"
-          *ngFor="let funding_organisation of record.metadata.funding_organisations">
-          {{ funding_organisation.agent.preferred_name }}
-          <dl class="row mb-0" *ngIf="funding_organisation.identifiedBy">
-            <dt class="col-sm-2" translate>Identifier</dt>
-            <dd class="col-sm-10">
-              <sonar-record-identifier [type]="funding_organisation.identifiedBy.type"
-                [value]="funding_organisation.identifiedBy.value" [source]="funding_organisation.identifiedBy.source">
-              </sonar-record-identifier>
-            </dd>
-          </dl>
-        </li>
-      </ul>
-    </dd>
+            </dl>
+          </li>
+        </ul>
+      </dd>
+    </ng-container>
   </dl>
 
   <ng-container *ngIf="record.metadata.documents && record.metadata.documents.length > 0">

--- a/projects/sonar/src/app/record/project/detail/detail.component.html
+++ b/projects/sonar/src/app/record/project/detail/detail.component.html
@@ -81,4 +81,14 @@
       </ul>
     </dd>
   </dl>
+
+  <ng-container *ngIf="record.metadata.documents && record.metadata.documents.length > 0">
+    <h4 translate>Linked documents</h4>
+    <ul>
+      <li *ngFor="let document of record.metadata.documents">
+        <a
+          [routerLink]="['/', 'records', 'documents', 'detail', document.pid]">{{ document.title[0].mainTitle | languageValue }}</a>
+      </li>
+    </ul>
+  </ng-container>
 </ng-container>

--- a/projects/sonar/src/app/record/project/detail/detail.component.html
+++ b/projects/sonar/src/app/record/project/detail/detail.component.html
@@ -1,0 +1,84 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2020 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ng-container *ngIf="record$ | async as record">
+  <h1 class="mb-4">{{ record.metadata.name }}</h1>
+  <dl class="row mt-4">
+    <ng-container *ngIf="record.metadata.description">
+      <dt class="col-sm-3" translate>Description</dt>
+      <dd class="col-sm-9" [innerHtml]="record.metadata.description | nl2br"></dd>
+    </ng-container>
+
+    <dt class="col-sm-3" translate>Start date</dt>
+    <dd class="col-sm-9">{{ record.metadata.startDate | dateTranslate: 'longDate' }}</dd>
+
+    <ng-container *ngIf="record.metadata.endDate">
+      <dt class="col-sm-3" translate>End date</dt>
+      <dd class="col-sm-9">{{ record.metadata.endDate | dateTranslate: 'longDate' }}</dd>
+    </ng-container>
+
+    <ng-container *ngIf="record.metadata.identifiedBy">
+      <dt class="col-sm-3" translate>Identifier</dt>
+      <dd class="col-sm-9">
+        <sonar-record-identifier [type]="record.metadata.identifiedBy.type" [value]="record.metadata.identifiedBy.value"
+          [source]="record.metadata.identifiedBy.source"></sonar-record-identifier>
+      </dd>
+    </ng-container>
+
+    <dt class="col-sm-3" translate>Investigators</dt>
+    <dd class="col-sm-9">
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item px-0 py-1" *ngFor="let investigator of record.metadata.investigators">
+          {{ investigator.agent.preferred_name }}<span class="badge badge-secondary text-light ml-1"
+            *ngFor="let role of investigator.role">{{ role | translate  }}</span>
+          <dl class="row mb-0" *ngIf="investigator.affiliation || investigator.identifiedBy">
+            <ng-container *ngIf="investigator.affiliation">
+              <dt class="col-sm-2" translate>Affiliation</dt>
+              <dd class="col-sm-10 mb-0">{{ investigator.affiliation }}</dd>
+            </ng-container>
+
+            <ng-container *ngIf="investigator.identifiedBy">
+              <dt class="col-sm-2" translate>Identifier</dt>
+              <dd class="col-sm-10">
+                <sonar-record-identifier [type]="investigator.identifiedBy.type"
+                  [value]="investigator.identifiedBy.value" [source]="investigator.identifiedBy.source">
+                </sonar-record-identifier>
+              </dd>
+            </ng-container>
+          </dl>
+        </li>
+      </ul>
+    </dd>
+
+    <dt class="col-sm-3" translate>Funding organisations</dt>
+    <dd class="col-sm-9">
+      <ul class="list-group list-group-flush">
+        <li class="list-group-item px-0 py-1"
+          *ngFor="let funding_organisation of record.metadata.funding_organisations">
+          {{ funding_organisation.agent.preferred_name }}
+          <dl class="row mb-0" *ngIf="funding_organisation.identifiedBy">
+            <dt class="col-sm-2" translate>Identifier</dt>
+            <dd class="col-sm-10">
+              <sonar-record-identifier [type]="funding_organisation.identifiedBy.type"
+                [value]="funding_organisation.identifiedBy.value" [source]="funding_organisation.identifiedBy.source">
+              </sonar-record-identifier>
+            </dd>
+          </dl>
+        </li>
+      </ul>
+    </dd>
+  </dl>
+</ng-container>

--- a/projects/sonar/src/app/record/project/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/project/detail/detail.component.ts
@@ -1,0 +1,26 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2020 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Component({
+  templateUrl: './detail.component.html'
+})
+export class DetailComponent {
+  /** Observable resolving record data */
+  record$: Observable<any>;
+}

--- a/projects/sonar/src/manual_translations.ts
+++ b/projects/sonar/src/manual_translations.ts
@@ -178,6 +178,10 @@ _('contribution_role_cre');
 _('contribution_role_prt');
 _('contribution_role_dgs');
 
+// Investigator role
+_('investigator');
+_('coinvestigator');
+
 // Deposit status
 _('deposit_status_in_progress');
 _('deposit_status_to_validate');

--- a/projects/sonar/src/styles.scss
+++ b/projects/sonar/src/styles.scss
@@ -97,6 +97,7 @@ pre {
 }
 
 .step-contributors .content,
+.step-projects .content,
 .editor-title .content,
 .header {
   margin-left: map-get($spacers, 3);


### PR DESCRIPTION
* Activates `projects` step in deposit process.
* Displays projects names in deposit preview.
* Adds special CSS styles for projects section.
* Forces long mode in editor to be able to remove fields.
* Tests existence of investigators and funding organisations in project detail view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>