### PR TITLE
gh actions: set the stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: "Mark stale issues/PR"
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Make issue/PR as stale after 6 months
+        days-before-stale: 180
+        # Do not close issue/PR marked as stale (will be changed later)
+        days-before-close: 0
+        stale-issue-message: 'This issue is stale because it has been open 6 months with no activity.'
+        stale-pr-message: 'This PR is stale because it has been open 6 months with no activity.'
+        # Set the label added to issue marked as stale (leave default value)
+        # stale-issue-label: 'stale'
+        # Set the label added to the PR marked stale
+        stale-pr-label: 'stale'
+        # Labels on an issue exempted from being marked as stale
+        exempt-issue-labels: 'bug'
+        exempt-pr-labels: 'translations'


### PR DESCRIPTION
* Adds a workflow for GitHub actions that mark issues and PR as stale
when they are open with no activites for 6 months. No PR or issue will
be closed (maybe in a future move).
* Some labels are excepted.
* Closes rero/sonar#446.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>