### PR TITLE
project: update link to public interface

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -57,7 +57,7 @@
               </a>
               <div class="dropdown-menu dropdown-menu-right" *dropdownMenu>
                 <h6 class="dropdown-header">{{ user.email }}</h6>
-                <a class="dropdown-item" href="/" translate>Public interface</a>
+                <a class="dropdown-item" [href]="publicInterfaceLink" translate>Public interface</a>
                 <a class="dropdown-item" href="/users/profile" translate>Profile</a>
                 <a class="dropdown-item" href="/manage/" translate>Administration</a>
                 <a class="dropdown-item" href="/logout/" translate>Logout</a>

--- a/projects/sonar/src/app/_layout/admin/admin.component.ts
+++ b/projects/sonar/src/app/_layout/admin/admin.component.ts
@@ -58,6 +58,23 @@ export class AdminComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Return the link to public interface, depending on user's organisation.
+   *
+   * @returns Link to public interface.
+   */
+  get publicInterfaceLink(): string {
+    if (
+      this.user &&
+      this.user.organisation &&
+      this.user.organisation.isDedicated
+    ) {
+      return `/${this.user.organisation.code}`;
+    }
+
+    return '/';
+  }
+
+  /**
    * Return the list of available languages.
    *
    * @returns List of languages.


### PR DESCRIPTION
* Adds the dedicated context to the link for the public interface, if user's organisation is flagged as dedicated.
* Closes rero/sonar#499.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>