### PR TITLE
resources: use `id` property for records

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -151,7 +151,7 @@ export class AppRoutingModule {
           {
             key: 'users',
             redirectUrl: (record: any) => {
-              return of(`/users/profile/${record.metadata.pid}`);
+              return of(`/users/profile/${record.id}`);
             }
           }
         ]
@@ -230,6 +230,7 @@ export class AppRoutingModule {
         editorSettings: {
           longMode: true
         },
+        recordResource: true,
         aggregationsExpand: ['organisation', 'user'],
         aggregationsOrder: ['organisation', 'user']
       }
@@ -261,6 +262,7 @@ export class AppRoutingModule {
               aggregationsBucketSize: 10,
               files: config.files || null,
               searchFields: config.searchFields || null,
+              recordResource: config.recordResource || null,
               canAdd: () => this._can(config.type, 'add'),
               canUpdate: (record: any) => this._can(config.type, 'update', record),
               canDelete: (record: any) => this._can(config.type, 'delete', record),

--- a/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ng-template #defaultTitle>{{ 'Deposit' | translate }} #{{ record.metadata.pid }}</ng-template>
+<ng-template #defaultTitle>{{ 'Deposit' | translate }} #{{ record.id }}</ng-template>
 
 <ng-container *ngIf="record && user">
   <div class="float-right"></div>
@@ -85,13 +85,13 @@
   </div>
 
   <div *ngIf="canContinueProcess()">
-    <a href class="btn btn-primary btn-small" [routerLink]="['/deposit', record.metadata.pid, 'create']" translate>
+    <a href class="btn btn-primary btn-small" [routerLink]="['/deposit', record.id, 'create']" translate>
       Continue process
     </a>
   </div>
 
   <div *ngIf="canReview()">
-    <a href class="btn btn-primary btn-small" [routerLink]="['/deposit', record.metadata.pid, 'create']" translate>
+    <a href class="btn btn-primary btn-small" [routerLink]="['/deposit', record.id, 'create']" translate>
       Review deposit
     </a>
   </div>

--- a/projects/sonar/src/app/deposit/upload/upload.component.ts
+++ b/projects/sonar/src/app/deposit/upload/upload.component.ts
@@ -338,7 +338,7 @@ export class UploadComponent implements OnInit, AfterContentChecked, OnDestroy {
       )
       .subscribe((deposit: any) => {
         this._spinner.hide();
-        this._router.navigate(['deposit', deposit.metadata.pid, 'metadata']);
+        this._router.navigate(['deposit', deposit.id, 'metadata']);
       });
   }
 


### PR DESCRIPTION
* Uses `id` property instead of `metadata.pid` as this property not exists anymore with resource management with `invenio-records-resources.` module.
* Flags `projects` resource a managed by `invenio-records-resources`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>