### PR TITLE
documents: configure open access filter

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -135,6 +135,12 @@ export class AppRoutingModule {
                 label: this._translateService.instant('Full-text'),
                 path: 'fulltext'
               }
+            ],
+            searchFilters: [
+              {
+                label: this._translateService.instant('Open access'),
+                filter: 'open_access'
+              }
             ]
           }
         ]


### PR DESCRIPTION
Configures a filter to search only for open access documents.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>