### PR TITLE
documents: handle custom fields for organisations

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -129,7 +129,10 @@ export class AppRoutingModule {
               'author',
               'subject',
               'organisation',
-              'sections'
+              'sections',
+              'customField1',
+              'customField2',
+              'customField3'
             ],
             aggregationsBucketSize: 10,
             searchFields: [
@@ -196,7 +199,10 @@ export class AppRoutingModule {
           'author',
           'subject',
           'organisation',
-          'sections'
+          'sections',
+          'customField1',
+          'customField2',
+          'customField3'
         ],
         editorSettings: {
           longMode: true
@@ -232,6 +238,9 @@ export class AppRoutingModule {
         files: {
           enabled: true
         },
+        editorSettings: {
+          longMode: true
+        }
       },
       {
         type: 'deposits',

--- a/projects/sonar/src/app/app.component.ts
+++ b/projects/sonar/src/app/app.component.ts
@@ -14,10 +14,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClient } from '@angular/common/http';
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import {
   LangChangeEvent,
-  TranslateService as NgxTranslateService,
+  TranslateService as NgxTranslateService
 } from '@ngx-translate/core';
 import { TranslateService } from '@rero/ng-core';
 import cookie from 'cookie';
@@ -39,7 +40,8 @@ export class AppComponent implements OnDestroy, OnInit {
    */
   constructor(
     private _translateService: TranslateService,
-    private _ngxTranslateService: NgxTranslateService
+    private _ngxTranslateService: NgxTranslateService,
+    private _httpClient: HttpClient
   ) {}
 
   /**
@@ -48,7 +50,12 @@ export class AppComponent implements OnDestroy, OnInit {
   ngOnInit() {
     this._changeLanguageSubscription = this._ngxTranslateService.onLangChange.subscribe(
       (event: LangChangeEvent) => {
-        document.cookie = `lang=${event.lang}`;
+        document.cookie = `lang=${event.lang}; path=/`;
+        // Change the language in flask application. Mandatory to set the responseType
+        // as `text` to avoid an error in the response.
+        this._httpClient
+          .get(`/lang/${event.lang}`, { responseType: 'text' })
+          .subscribe();
       }
     );
 

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -34,9 +34,9 @@
       </div>
       <div class="col">
         <h1 class="text-primary">
-          <span [innerHTML]="record.title[0].mainTitle | languageValue | nl2br"></span>
+          <span [innerHTML]="record.title[0].mainTitle | languageValue | async | nl2br"></span>
           <ng-container *ngIf="record.title[0].subtitle">
-            &nbsp;:&nbsp;{{ record.title[0].subtitle | languageValue }}</ng-container>
+            &nbsp;:&nbsp;{{ record.title[0].subtitle | languageValue | async }}</ng-container>
         </h1>
 
         <!-- CONTRIBUTORS-->
@@ -63,8 +63,9 @@
               </li>
             </ng-container>
           </ul>
-          <a href="#" (click)="showMoreContributors($event)"
-            *ngIf="record.contribution.length > 3">{{ 'Show more' | translate }}&hellip;</a>
+          <a href="#" (click)="showMoreContributors($event)" *ngIf="record.contribution.length > 3">
+            {{ 'Show more' | translate }}&hellip;
+          </a>
         </div>
 
         <!-- PUBLICATION STATEMENT -->
@@ -114,13 +115,16 @@
         <div class="my-4 text-justify" *ngIf="record.abstracts.length > 0">
           <a href="#" class="abstract-lang badge badge-secondary text-light mr-1"
             [ngClass]="{'badge-secondary text-light': abstract.show, 'badge-light text-reset': !abstract.show}"
-            (click)="$event.preventDefault(); changeAbstract(abstract)"
-            *ngFor="let abstract of record.abstracts">{{ abstract.language | translateLanguage }}</a>
+            (click)="$event.preventDefault(); changeAbstract(abstract)" *ngFor="let abstract of record.abstracts">
+            {{ abstract.language | translateLanguage }}
+          </a>
           <span *ngFor="let abstract of record.abstracts">
             <ng-container *ngIf="abstract.show">
               <ng-container *ngIf="!abstract.full && abstract.value.length > 400; else fullAbstract">
-                {{ abstract.value | slice:0:400 }} <a href="#"
-                  (click)="showMoreAbstract($event, abstract)">{{ 'Show more' | translate }}&hellip;</a>
+                {{ abstract.value | slice:0:400 }}
+                <a href="#" (click)="showMoreAbstract($event, abstract)">
+                  {{ 'Show more' | translate }}&hellip;
+                </a>
               </ng-container>
               <ng-template #fullAbstract>
                 <span [innerHtml]="abstract.value | nl2br"></span>
@@ -152,8 +156,10 @@
             </dt>
             <dd class="col-lg-8">
               <p class="m-0" *ngFor="let otherEdition of record.otherEdition">
-                {{ otherEdition.publicNote }} : <a [href]="otherEdition.document.electronicLocator"
-                  target="_blank">{{ otherEdition.document.electronicLocator }}</a>
+                {{ otherEdition.publicNote }} :
+                <a [href]="otherEdition.document.electronicLocator" target="_blank">
+                  {{ otherEdition.document.electronicLocator }}
+                </a>
               </p>
             </dd>
           </ng-container>
@@ -192,6 +198,21 @@
                 {{ ('classification_' + classification.classificationPortion) | translate }}
               </ng-container>
             </dd>
+          </ng-container>
+
+          <ng-container *ngFor="let i of [1, 2, 3]">
+            <ng-container *ngIf="record['customField' + i]">
+              <dt class="col-lg-4"
+                *ngIf="record.organisation && record.organisation[0]['documentsCustomField' + i] && record.organisation[0]['documentsCustomField' + i].label; else noLabel">
+                {{ record.organisation[0]['documentsCustomField' + i].label | languageValue | async }}
+              </dt>
+              <ng-template #noLabel>
+                <dt class="col-lg-4">{{ 'Custom field' | translate }} {{ i }}</dt>
+              </ng-template>
+              <dd class="col-lg-8">
+                {{ record['customField' + i].join(', ') }}
+              </dd>
+            </ng-container>
           </ng-container>
 
           <!-- LICENSE -->

--- a/projects/sonar/src/app/record/document/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/document/detail/detail.component.ts
@@ -104,7 +104,7 @@ export class DetailComponent implements OnDestroy, OnInit {
     this._subscription.add(
       this._translateService.onLangChange.subscribe(() => {
         this.sortAbstracts();
-        if (this.record.abstracts.length > 0) {
+        if (this.record && this.record.abstracts.length > 0) {
           this.changeAbstract(this.record.abstracts[0]);
         }
       })
@@ -266,6 +266,10 @@ export class DetailComponent implements OnDestroy, OnInit {
    * language of the interface.
    */
   private sortAbstracts() {
+    if (!this.record || !this.record.abstracts) {
+      return;
+    }
+
     const firstLanguage = this._configSservice.languagesMap.find(
       (item) => item.code === this._translateService.currentLang
     );

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -24,13 +24,13 @@
   <div class="col-12 col-lg-10">
     <h4 class="mb-2">
       <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
-        <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | nl2br"></span><ng-container *ngIf="record.metadata.title[0].subtitle">
-          :&nbsp;{{ record.metadata.title[0].subtitle | languageValue }}</ng-container>
+        <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span><ng-container *ngIf="record.metadata.title[0].subtitle">
+          :&nbsp;{{ record.metadata.title[0].subtitle | languageValue | async }}</ng-container>
       </a>
       <ng-template #routingLink>
         <a [routerLink]="detailUrl.link">
-          <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | nl2br"></span><ng-container
-            *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle | languageValue }}
+          <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span><ng-container
+            *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle | languageValue | async }}
           </ng-container>
         </a>
       </ng-template>

--- a/projects/sonar/src/app/record/hepvs/project/detail/detail.component.html
+++ b/projects/sonar/src/app/record/hepvs/project/detail/detail.component.html
@@ -209,7 +209,7 @@
       <ul>
         <li *ngFor="let document of record.metadata.documents">
           <a [routerLink]="['/', 'records', 'documents', 'detail', document.pid]">
-            {{ document.title[0].mainTitle | languageValue }}
+            {{ document.title[0].mainTitle | languageValue | async }}
           </a>
         </li>
       </ul>

--- a/projects/sonar/src/app/record/organisation/detail/detail.component.html
+++ b/projects/sonar/src/app/record/organisation/detail/detail.component.html
@@ -37,5 +37,18 @@
     <dd class="col-sm-9">
       <i class="fa fa-{{ record.metadata.isDedicated ? 'check' : 'close' }}"></i>
     </dd>
+
+    <ng-container *ngFor="let i of [1, 2, 3]">
+      <ng-container *ngIf="record.metadata['documentsCustomField' + i]">
+        <dt class="col-sm-3">{{ 'Custom field' | translate }} {{ i }}</dt>
+        <dd class="col-sm-9">
+          <ng-container *ngIf="record.metadata['documentsCustomField' + i].label">
+            {{ 'Label' | translate }}: {{ record.metadata['documentsCustomField' + i].label | languageValue | async }}<br>
+          </ng-container>
+          <i class="fa fa-{{ record.metadata['documentsCustomField' + i].includeInFacets ? 'check' : 'remove' }}"></i>
+          {{ 'Include in facets' | translate }}
+        </dd>
+      </ng-container>
+    </ng-container>
   </dl>
 </ng-container>

--- a/projects/sonar/src/app/record/project/detail/detail.component.html
+++ b/projects/sonar/src/app/record/project/detail/detail.component.html
@@ -87,7 +87,7 @@
       <ul>
         <li *ngFor="let document of record.metadata.documents">
           <a
-            [routerLink]="['/', 'records', 'documents', 'detail', document.pid]">{{ document.title[0].mainTitle | languageValue }}</a>
+            [routerLink]="['/', 'records', 'documents', 'detail', document.pid]">{{ document.title[0].mainTitle | languageValue | async }}</a>
         </li>
       </ul>
     </ng-container>

--- a/proxy.conf.json
+++ b/proxy.conf.json
@@ -52,5 +52,14 @@
     "pathRewrite": {
       "^/static/": "https://localhost:5000/static/"
     }
+  },
+  "/lang/*": {
+    "target": "https://localhost:5000",
+    "secure": false,
+    "logLevel": "debug",
+    "changeOrigin": true,
+    "pathRewrite": {
+      "^/lang": "https://localhost:5000/lang"
+    }
   }
 }


### PR DESCRIPTION
* Enables long mode for organisations editor.
* Adds custom fields in aggregations order.
* Displays the custom fields in documents detail view.
* Fixes an issue if document's abstract does not exist.
* Displays configuration for custom fields in organisations detail view.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>