### PR TITLE
documents: change `open_access` filter value

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -141,7 +141,8 @@ export class AppRoutingModule {
             searchFilters: [
               {
                 label: this._translateService.instant('Open access'),
-                filter: 'open_access'
+                filter: 'open_access',
+                value: 'true'
               }
             ]
           }


### PR DESCRIPTION
* Changes `open_access` filter value to be able to use it with terms filters in backend.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>