### PR TITLE
deposits: store document date extracted from PDF

### DIFF
--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -435,6 +435,10 @@ export class EditorComponent implements OnInit {
             this.deposit.metadata.language = result.languages[0];
           }
 
+          if (result.documentDate) {
+            this.deposit.metadata.documentDate = result.documentDate;
+          }
+
           if (result.publication) {
             this.deposit.metadata.publication = result.publication;
           }


### PR DESCRIPTION
Stores the document date when metadata an extracted from PDF.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>