### PR TITLE
project: add resource for subdivisions

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -25,21 +25,19 @@
         </button>
         <div class="collapse navbar-collapse" [collapse]="isCollapsed">
           <ul class="navbar-nav mr-auto">
-            <li class="nav-item" *ngIf="user.is_admin">
-              <a class="nav-link" routerLink="/records/organisations" translate>Organisations</a>
-            </li>
-            <li class="nav-item" *ngIf="user.is_admin">
-              <a class="nav-link" routerLink="/records/users" translate>Users</a>
-            </li>
-            <li class="nav-item dropdown" *ngIf="user.is_moderator" dropdown>
+            <li class="nav-item dropdown" *ngIf="user.is_admin" dropdown>
               <a class="nav-link dropdown-toggle" role="button" data-toggle="dropdown"
                 aria-haspopup="true" aria-expanded="false" dropdownToggle translate>
-                Documents
+                Administration
               </a>
               <div class="dropdown-menu dropdown-menu-right" *dropdownMenu>
-                <a class="dropdown-item" routerLink="/records/documents" translate>Documents</a>
-                <a class="dropdown-item" routerLink="/records/collections" translate>Collections</a>
+                <a class="dropdown-item" [routerLink]="'/records/' + item" *ngFor="let item of ['collections', 'organisations', 'subdivisions', 'users']">
+                  {{ item | ucfirst | translate }}
+                </a>
               </div>
+            </li>
+            <li class="nav-item" *ngIf="user.is_moderator">
+              <a class="nav-link" routerLink="/records/documents" translate>Documents</a>
             </li>
             <li class="nav-item" *ngIf="user.is_submitter">
               <a class="nav-link" routerLink="/records/projects" translate>Research projects</a>

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -38,6 +38,8 @@ import { DetailComponent as OrganisationDetailComponent } from './record/organis
 import { OrganisationComponent } from './record/organisation/organisation.component';
 import { BriefViewComponent as ProjectBriefViewComponent } from './record/project/brief-view/brief-view.component';
 import { DetailComponent as ProjectDetailComponent } from './record/project/detail/detail.component';
+import { BriefViewComponent as SubdivisionBriefViewComponent } from './record/subdivision/brief-view/brief-view.component';
+import { DetailComponent as SubdivisionDetailComponent } from './record/subdivision/detail/detail.component';
 import { DetailComponent as UserDetailComponent } from './record/user/detail/detail.component';
 import { UserComponent } from './record/user/user.component';
 import { UserService } from './user.service';
@@ -131,7 +133,7 @@ export class AppRoutingModule {
               'author',
               'subject',
               'organisation',
-              'sections',
+              'subdivision',
               'customField1',
               'customField2',
               'customField3'
@@ -201,7 +203,7 @@ export class AppRoutingModule {
           'author',
           'subject',
           'organisation',
-          'sections',
+          'subdivision',
           'customField1',
           'customField2',
           'customField3'
@@ -230,7 +232,11 @@ export class AppRoutingModule {
       {
         type: 'users',
         briefView: UserComponent,
-        detailView: UserDetailComponent
+        detailView: UserDetailComponent,
+        aggregationsOrder: ['subdivision'],
+        editorSettings: {
+          longMode: true
+        }
       },
       {
         type: 'organisations',
@@ -248,7 +254,7 @@ export class AppRoutingModule {
         briefView: BriefViewComponent,
         aggregations: AggregationFilter.filter,
         aggregationsExpand: ['status', 'user', 'contributor'],
-        aggregationsOrder: ['status', 'user', 'contributor']
+        aggregationsOrder: ['status', 'user', 'contributor', 'subdivision']
       },
       {
         type: 'projects',
@@ -276,6 +282,15 @@ export class AppRoutingModule {
         files: {
           enabled: true
         },
+        editorSettings: {
+          longMode: true
+        }
+      },
+      {
+        type: 'subdivisions',
+        label: 'Subdivisions',
+        briefView: SubdivisionBriefViewComponent,
+        detailView: SubdivisionDetailComponent,
         editorSettings: {
           longMode: true
         }

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -58,6 +58,8 @@ import { DetailComponent as OrganisationDetailComponent } from './record/organis
 import { OrganisationComponent } from './record/organisation/organisation.component';
 import { BriefViewComponent as ProjectBriefViewComponent } from './record/project/brief-view/brief-view.component';
 import { DetailComponent as ProjectDetailComponent } from './record/project/detail/detail.component';
+import { BriefViewComponent as SubdivisionBriefViewComponent } from './record/subdivision/brief-view/brief-view.component';
+import { DetailComponent as SubdivisionDetailComponent } from './record/subdivision/detail/detail.component';
 import { DetailComponent as UserDetailComponent } from './record/user/detail/detail.component';
 import { UserComponent } from './record/user/user.component';
 import { ValidationComponent } from './record/validation/validation.component';
@@ -97,7 +99,9 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     HepvsProjectDetailComponent,
     ValidationComponent,
     CollectionBriefViewComponent,
-    CollectionDetailComponent
+    CollectionDetailComponent,
+    SubdivisionBriefViewComponent,
+    SubdivisionDetailComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -40,6 +40,19 @@
             &nbsp;:&nbsp;{{ record.title[0].subtitle | languageValue | async }}</ng-container>
         </h1>
 
+        <h4 class="m-0">
+          <ng-container *ngIf="record.organisation">
+            <span class="badge badge-secondary text-light mr-1 font-weight-normal" *ngFor="let organisation of record.organisation">
+              {{ organisation.name }}
+            </span>
+          </ng-container>
+          <ng-container *ngIf="record.subdivisions">
+            <span class="badge badge-secondary text-light mr-1 font-weight-normal" *ngFor="let subdivision of record.subdivisions">
+              {{ subdivision.name | languageValue | async }}
+            </span>
+          </ng-container>
+        </h4>
+
         <!-- CONTRIBUTORS-->
         <div class="my-2" *ngIf="record.contribution.length > 0">
           <ul class="list-unstyled m-0">
@@ -194,7 +207,7 @@
           </ng-container>
 
           <!-- CLASSIFICATION -->
-          <ng-container *ngIf="UDCclassifiations">
+          <ng-container *ngIf="UDCclassifiations.length">
             <dt class="col-lg-4" translate>Classification</dt>
             <dd class="col-lg-8">
               <ng-container *ngFor="let classification of UDCclassifiations; let last = last;">

--- a/projects/sonar/src/app/record/document/document.component.html
+++ b/projects/sonar/src/app/record/document/document.component.html
@@ -16,25 +16,55 @@
 -->
 <div class="row">
   <div class="col-2 d-none d-lg-block text-center">
-    <sonar-document-file [file]="mainFile" [showLabel]="false" [showPreview]="false" [showDownload]="false" [showExternalLink]="false" [link]="detailUrl.link" [inRouter]="!detailUrl.external"></sonar-document-file>
+    <ng-container *ngIf="detailUrl; else imageWithoutLink">
+      <sonar-document-file [file]="mainFile" [showLabel]="false" [showPreview]="false" [showDownload]="false"
+        [showExternalLink]="false" [link]="detailUrl.link" [inRouter]="!detailUrl.external"></sonar-document-file>
+    </ng-container>
+    <ng-template #imageWithoutLink>
+      <sonar-document-file [file]="mainFile" [showLabel]="false" [showPreview]="false" [showDownload]="false"
+        [showExternalLink]="false"></sonar-document-file>
+    </ng-template>
     <p class="my-2" *ngIf="record.metadata.documentType">
       <small>{{ ('document_type_' + record.metadata.documentType) | translate }}</small>
     </p>
   </div>
   <div class="col-12 col-lg-10">
     <h4 class="mb-2">
-      <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
-        <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span><ng-container *ngIf="record.metadata.title[0].subtitle">
-          :&nbsp;{{ record.metadata.title[0].subtitle | languageValue | async }}</ng-container>
-      </a>
-      <ng-template #routingLink>
-        <a [routerLink]="detailUrl.link">
-          <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span><ng-container
-            *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle | languageValue | async }}
+      <ng-container *ngIf="detailUrl; else titleWithoutLink">
+        <a [href]="detailUrl.link" *ngIf="detailUrl.external; else routingLink">
+          <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span>
+          <ng-container *ngIf="record.metadata.title[0].subtitle">
+            :&nbsp;{{ record.metadata.title[0].subtitle | languageValue | async }}
           </ng-container>
         </a>
+        <ng-template #routingLink>
+          <a [routerLink]="detailUrl.link">
+            <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span>
+            <ng-container *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle |
+              languageValue | async }}
+            </ng-container>
+          </a>
+        </ng-template>
+      </ng-container>
+      <ng-template #titleWithoutLink>
+        <span [innerHTML]="record.metadata.title[0].mainTitle | languageValue | async | nl2br"></span>
+        <ng-container *ngIf="record.metadata.title[0].subtitle">:&nbsp;{{ record.metadata.title[0].subtitle |
+          languageValue | async }}
+        </ng-container>
       </ng-template>
     </h4>
+    <p class="mt-0 mb-1">
+      <ng-container *ngIf="record.metadata.organisation">
+        <span class="badge badge-secondary text-light mr-1" *ngFor="let organisation of record.metadata.organisation">
+          {{ organisation.name }}
+        </span>
+      </ng-container>
+      <ng-container *ngIf="record.metadata.subdivisions">
+        <span class="badge badge-secondary text-light mr-1" *ngFor="let subdivision of record.metadata.subdivisions">
+          {{ subdivision.name | languageValue | async }}
+        </span>
+      </ng-container>
+    </p>
     <p class="mb-0">
       <ng-container *ngFor="let contributor of record.metadata.contribution; let first = first;">
         <ng-container *ngIf="!first">&nbsp;;&nbsp;</ng-container>
@@ -42,9 +72,11 @@
       </ng-container>
     </p>
     <p class="my-0 d-none d-lg-block" *ngIf="record.metadata.partOf && record.metadata.partOf.length > 0">
-      {{ record.metadata.partOf[0] | publication }}</p>
+      {{ record.metadata.partOf[0] | publication }}
+    </p>
     <p class="my-0  d-none d-lg-block" *ngIf="record.metadata.dissertation">{{ record.metadata.dissertation.text }}</p>
-    <ul class="list-unstyled m-0" *ngIf="record.metadata.provisionActivity && record.metadata.provisionActivity.length > 0">
+    <ul class="list-unstyled m-0"
+      *ngIf="record.metadata.provisionActivity && record.metadata.provisionActivity.length > 0">
       <ng-container *ngFor="let statement of record.metadata.provisionActivity">
         <ng-container *ngIf="statement.text && statement.text.default">
           <li *ngFor="let item of statement.text | keyvalue">

--- a/projects/sonar/src/app/record/organisation/detail/detail.component.html
+++ b/projects/sonar/src/app/record/organisation/detail/detail.component.html
@@ -14,7 +14,7 @@
  You should have received a copy of the GNU Affero General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<ng-container *ngIf="record$ | async as record">
+<ng-container *ngIf="record">
   <h1 class="mb-4">{{ record.metadata.name }}</h1>
   <dl class="row mt-4">
     <dt class="col-sm-3" translate>Code</dt>
@@ -43,7 +43,8 @@
         <dt class="col-sm-3">{{ 'Custom field' | translate }} {{ i }}</dt>
         <dd class="col-sm-9">
           <ng-container *ngIf="record.metadata['documentsCustomField' + i].label">
-            {{ 'Label' | translate }}: {{ record.metadata['documentsCustomField' + i].label | languageValue | async }}<br>
+            {{ 'Label' | translate }}: {{ record.metadata['documentsCustomField' + i].label | languageValue | async }}
+            <br>
           </ng-container>
           <i class="fa fa-{{ record.metadata['documentsCustomField' + i].includeInFacets ? 'check' : 'remove' }}"></i>
           {{ 'Include in facets' | translate }}
@@ -51,4 +52,30 @@
       </ng-container>
     </ng-container>
   </dl>
+
+  <div class="row mt-3">
+    <div class="col" *ngIf="subdivisions.length">
+      <div class="card mt-3">
+        <div class="card-header font-weight-bold" translate>Subdivisions</div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item" *ngFor="let subdivision of subdivisions">
+            <a [routerLink]="['/', 'records', 'subdivisions', 'detail', subdivision.id]">
+              {{ subdivision.metadata.name | languageValue | async }}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div class="col" *ngIf="collections.length">
+      <div class="card mt-3">
+        <div class="card-header font-weight-bold" translate>Collections</div>
+        <ul class="list-group list-group-flush">
+          <li class="list-group-item" *ngFor="let collection of collections">
+            <a [routerLink]="['/', 'records', 'collections', 'detail', collection.id]">
+              {{ collection.metadata.name | languageValue | async }}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
 </ng-container>

--- a/projects/sonar/src/app/record/subdivision/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/record/subdivision/brief-view/brief-view.component.html
@@ -1,0 +1,20 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2021 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+
+<h4>
+  <a routerLink="{{ detailUrl.link }}">{{ record.metadata.name | languageValue | async }}</a>
+</h4>

--- a/projects/sonar/src/app/record/subdivision/brief-view/brief-view.component.ts
+++ b/projects/sonar/src/app/record/subdivision/brief-view/brief-view.component.ts
@@ -1,0 +1,32 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component } from '@angular/core';
+import { ResultItem } from '@rero/ng-core';
+
+@Component({
+  templateUrl: './brief-view.component.html'
+})
+export class BriefViewComponent implements ResultItem {
+  // Record data.
+  record: any;
+
+  // Resource type.
+  type: string;
+
+  // Detail URL object.
+  detailUrl: { link: string, external: boolean };
+}

--- a/projects/sonar/src/app/record/subdivision/detail/detail.component.html
+++ b/projects/sonar/src/app/record/subdivision/detail/detail.component.html
@@ -1,0 +1,19 @@
+<!--
+ SONAR User Interface
+ Copyright (C) 2021 RERO
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU Affero General Public License as published by
+ the Free Software Foundation, version 3 of the License.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ GNU Affero General Public License for more details.
+
+ You should have received a copy of the GNU Affero General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+<ng-container *ngIf="record$ | async as record">
+  <h1 class="mb-4">{{ record.metadata.name | languageValue | async }}</h1>
+</ng-container>

--- a/projects/sonar/src/app/record/subdivision/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/subdivision/detail/detail.component.ts
@@ -1,0 +1,26 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+
+@Component({
+  templateUrl: './detail.component.html'
+})
+export class DetailComponent {
+  /** Observable resolving record data */
+  record$: Observable<any>;
+}

--- a/projects/sonar/src/app/record/user/detail/detail.component.html
+++ b/projects/sonar/src/app/record/user/detail/detail.component.html
@@ -25,6 +25,11 @@
     <dt class="col-sm-3" translate>Role</dt>
     <dd class="col-sm-9">{{ ('role_' + record.metadata.role) | translate }}</dd>
 
+    <ng-container *ngIf="record.metadata.subdivision">
+      <dt class="col-sm-3" translate>Subdivision</dt>
+      <dd class="col-sm-9">{{ record.metadata.subdivision.name | languageValue | async }}</dd>
+    </ng-container>
+
     <dt class="col-sm-3" translate>Email address</dt>
     <dd class="col-sm-9">{{ record.metadata.email }}</dd>
 

--- a/projects/sonar/src/app/record/user/user.component.html
+++ b/projects/sonar/src/app/record/user/user.component.html
@@ -25,6 +25,9 @@
   <span *ngIf="record.metadata.organisation; else noOrganisation">
     - {{ record.metadata.organisation.name }}
   </span>
+  <ng-container *ngIf="record.metadata.subdivision">
+    - {{ record.metadata.subdivision.name | languageValue | async }}
+  </ng-container>
   <ng-template #noOrganisation>
     <span class="text-info ml-2">
       <i class="fa fa-info-circle"></i>


### PR DESCRIPTION
* Adds configuration to manage subdivisions in administration.
* Creates a brief view to display subdivisions items.
* Creates a detail view to display a subdivision.
* Adds a link to subdivisions in admin menu.
* Reorganizes the admin navigation.
* Adds facet for `subdivisions` in documents.
* Adds facet for `subdivisions` in deposits.
* Adds facet for `subdivisions` in users.
* Displays subdivisions info in document detail view in admin.
* Displays subdivisions info in the user detail view.
* Displays organisations and subdivisions in document brief view.
* Displays organisations and subdivisions in document detail view below the title.
* Displays subdivisions and collections in organisation detail view.
* Displays subdivisions in user brief view.
* Enables editor long mode for users.
* Checks the existence of the link to detail in documents brief view to avoid an error.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>