### PR TITLE
users: remove `missing_organisations` aggregation

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -230,8 +230,7 @@ export class AppRoutingModule {
       {
         type: 'users',
         briefView: UserComponent,
-        detailView: UserDetailComponent,
-        aggregationsOrder: ['missing_organisation']
+        detailView: UserDetailComponent
       },
       {
         type: 'organisations',


### PR DESCRIPTION
* Removes `missing_organisation` user as it is no more possible to
create a user without an associated organisation.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>