### PR TITLE
documents: aggregations order from backend

### DIFF
--- a/projects/sonar/src/app/app-config.service.ts
+++ b/projects/sonar/src/app/app-config.service.ts
@@ -22,9 +22,6 @@ import { environment } from '../environments/environment';
   providedIn: 'root',
 })
 export class AppConfigService extends CoreConfigService {
-  // View key for global search
-  globalSearchViewCode = 'global';
-
   // Languages map.
   languagesMap = [
     {

--- a/projects/sonar/src/app/record/document/aggregation-filter.ts
+++ b/projects/sonar/src/app/record/document/aggregation-filter.ts
@@ -20,9 +20,6 @@ import { Observable, Subscriber } from 'rxjs';
 export class AggregationFilter {
   static translateService: TranslateService;
 
-  // Default code for global search
-  static globalSearchViewCode: string;
-
   // Current view
   static view: string;
 


### PR DESCRIPTION
* Retrieves the aggregations order from backend.
* Removes unused property `globalSearchViewCode`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>