### PR TITLE
documents: aggregations order from backend

### DIFF
--- a/projects/sonar/src/app/app-config.service.ts
+++ b/projects/sonar/src/app/app-config.service.ts
@@ -22,9 +22,6 @@ import { environment } from '../environments/environment';
   providedIn: 'root',
 })
 export class AppConfigService extends CoreConfigService {
-  // View key for global search
-  globalSearchViewCode = 'global';
-
   // Languages map.
   languagesMap = [
     {

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -14,13 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { ActivationStart, Router, RouterEvent, RouterModule, Routes, UrlSegment } from '@angular/router';
+import { ActivatedRoute, ActivationStart, Router, RouterEvent, RouterModule, Routes, UrlSegment } from '@angular/router';
 import { TranslateService } from '@ngx-translate/core';
-import { ActionStatus, DetailComponent, EditorComponent, RecordSearchPageComponent } from '@rero/ng-core';
+import { ActionStatus, ApiService, DetailComponent, EditorComponent, RecordSearchPageComponent } from '@rero/ng-core';
 import { Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { AppConfigService } from './app-config.service';
+import { map, switchMap } from 'rxjs/operators';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { BriefViewComponent } from './deposit/brief-view/brief-view.component';
 import { ConfirmationComponent } from './deposit/confirmation/confirmation.component';
@@ -95,16 +95,19 @@ export class AppRoutingModule {
    *
    * @param _translateService Translate service.
    * @param _router Router service.
+   * @param _route Activated route.
    * @param _userService User service.
-   * @param _appConfigService Config service.
+   * @param _httpClient HTTP client.
+   * @param _apiService API service.
    */
   constructor(
     private _translateService: TranslateService,
     private _router: Router,
+    private _route: ActivatedRoute,
     private _userService: UserService,
-    private _appConfigService: AppConfigService
+    private _httpClient: HttpClient,
+    private _apiService: ApiService,
   ) {
-    AggregationFilter.globalSearchViewCode = this._appConfigService.globalSearchViewCode;
     AggregationFilter.translateService = this._translateService;
 
     this._router.config.push({
@@ -124,20 +127,7 @@ export class AppRoutingModule {
             component: DocumentComponent,
             aggregations: AggregationFilter.filter,
             aggregationsExpand: ['document_type', 'controlled_affiliation', 'year'],
-            aggregationsOrder: [
-              'document_type',
-              'controlled_affiliation',
-              'year',
-              'collection',
-              'language',
-              'author',
-              'subject',
-              'organisation',
-              'subdivision',
-              'customField1',
-              'customField2',
-              'customField3'
-            ],
+            aggregationsOrder: this._documentAggregationsOrder(),
             aggregationsBucketSize: 10,
             searchFields: [
               {
@@ -214,21 +204,7 @@ export class AppRoutingModule {
         detailView: DocumentDetailComponent,
         aggregations: AggregationFilter.filter,
         aggregationsExpand: ['document_type', 'controlled_affiliation', 'year'],
-        aggregationsOrder: [
-          'document_type',
-          'controlled_affiliation',
-          'year',
-          'collection',
-          'language',
-          'author',
-          'subject',
-          'organisation',
-          'subdivision',
-          'customField1',
-          'customField2',
-          'customField3',
-          'masked'
-        ],
+        aggregationsOrder: this._documentAggregationsOrder(),
         editorSettings: {
           longMode: true
         },
@@ -541,5 +517,34 @@ export class AppRoutingModule {
       consumed: segments,
       posParams: { type: new UrlSegment(url[1].path, {}) }
     };
+  }
+
+  /**
+   * Get the ordered list of aggregations.
+   *
+   * @returns An observable resolving the ordered list.
+   */
+  private _documentAggregationsOrder(): Observable<any> {
+    return of(null).pipe(
+      switchMap(() => {
+        const view = this._route.snapshot.children[0].params.view;
+
+        let params = new HttpParams();
+        if (view) {
+          params = params.set('view', view);
+        }
+        if (this._route.snapshot.children[0].queryParams.collection_view) {
+          params = params.set('collection', '1');
+        }
+
+        return this._httpClient.get(
+          `${this._apiService.getEndpointByType(
+            'documents',
+            true
+          )}/aggregations`,
+          { params }
+        );
+      })
+    );
   }
 }

--- a/projects/sonar/src/app/record/document/aggregation-filter.ts
+++ b/projects/sonar/src/app/record/document/aggregation-filter.ts
@@ -20,9 +20,6 @@ import { Observable, Subscriber } from 'rxjs';
 export class AggregationFilter {
   static translateService: TranslateService;
 
-  // Default code for global search
-  static globalSearchViewCode: string;
-
   // Current view
   static view: string;
 


### PR DESCRIPTION
* Retrieves the aggregations order from backend.
* Removes unused property `globalSearchViewCode`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>

## Why are you opening this PR?

- Which task/US does it implement?
- Which issue does it fix?

## How to test?

- What command should I have to run to test your PR?
- What should I test through the UI?

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
