### PR TITLE
menu: remove entries on administration menu

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.html
+++ b/projects/sonar/src/app/_layout/admin/admin.component.html
@@ -1,18 +1,18 @@
 <!--
- SONAR User Interface
- Copyright (C) 2021 RERO
-
- This program is free software: you can redistribute it and/or modify
- it under the terms of the GNU Affero General Public License as published by
- the Free Software Foundation, version 3 of the License.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- GNU Affero General Public License for more details.
-
- You should have received a copy of the GNU Affero General Public License
- along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  SONAR User Interface
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 <ng-container *ngIf="ready">
   <ng-container *ngIf="user; else errorTemplate">
@@ -31,7 +31,7 @@
                 Administration
               </a>
               <div class="dropdown-menu dropdown-menu-right" *dropdownMenu>
-                <a class="dropdown-item" [routerLink]="'/records/' + item" *ngFor="let item of ['collections', 'organisations', 'subdivisions', 'users']">
+                <a class="dropdown-item" [routerLink]="['/records/', item]" *ngFor="let item of administrationMenu">
                   {{ item | ucfirst | translate }}
                 </a>
               </div>

--- a/projects/sonar/src/app/_layout/admin/admin.component.ts
+++ b/projects/sonar/src/app/_layout/admin/admin.component.ts
@@ -55,6 +55,25 @@ export class AdminComponent implements OnInit, OnDestroy {
     private _httpClient: HttpClient
   ) {}
 
+  /**
+   * Administration menu entries
+   *
+   * @returns List of available entries in the admin menu.
+   */
+  get administrationMenu(): string[] {
+    let sections = ['collections', 'organisations', 'subdivisions', 'users'];
+    /** Delete menu entries if the organization is shared */
+    if (!(this._userService.isDedecatedOrganisation())) {
+      sections = ['organisations', 'users'];
+    }
+    return sections;
+  }
+
+  /**
+   * Get current language
+   *
+   * @returns current language.
+   */
   get currentLanguage(): string {
     return this._translateService.currentLanguage;
   }

--- a/projects/sonar/src/app/app-initializer.service.spec.ts
+++ b/projects/sonar/src/app/app-initializer.service.spec.ts
@@ -1,0 +1,51 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2022 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { AppInitializerService } from './app-initializer.service';
+import { UserService } from './user.service';
+
+
+describe('AppInitializerService', () => {
+  let service: AppInitializerService;
+  const result = {
+    metadata: {
+      first_name: 'foo',
+      last_name: 'bar'
+    }
+  };
+  const userServiceSpy = jasmine.createSpyObj('UserService', ['loadLoggedUser']);
+  userServiceSpy.loadLoggedUser.and.returnValue(of(result));
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: UserService, useValue: userServiceSpy }
+      ]
+    });
+    service = TestBed.inject(AppInitializerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('Should return an object on initialization', () => {
+    service.initialize().subscribe((user) => {
+      expect(user).toEqual(result);
+    });
+  });
+});

--- a/projects/sonar/src/app/app-initializer.service.ts
+++ b/projects/sonar/src/app/app-initializer.service.ts
@@ -1,0 +1,32 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2022 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { UserService } from './user.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppInitializerService {
+
+  constructor(private _userService: UserService) { }
+
+  /** Function called when launching the application */
+  initialize(): Observable<any> {
+    return this._userService.loadLoggedUser();
+  }
+}

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -197,7 +197,7 @@ export class AppRoutingModule {
       return ProjectDetailComponent;
     }));
 
-    const recordsRoutesConfiguration = [
+    let recordsRoutesConfiguration = [
       {
         type: 'documents',
         briefView: DocumentComponent,
@@ -398,45 +398,55 @@ export class AppRoutingModule {
       }
     ];
 
-    recordsRoutesConfiguration.forEach((config: any) => {
-      const route = {
-        matcher: (url: any) => this._routeMatcher(url, config.type),
-        canActivate: [RoleGuard],
-        children: [
-          { path: '', component: RecordSearchPageComponent },
-          { path: 'detail/:pid', component: DetailComponent },
-          { path: 'edit/:pid', component: EditorComponent },
-          { path: 'new', component: EditorComponent, canActivate: [CanAddGuard] }
-        ],
-        data: {
-          role: 'submitter',
-          showSearchInput: true,
-          types: [
-            {
-              key: config.type,
-              label: config.label || config.type.charAt(0).toUpperCase() + config.type.slice(1),
-              component: config.briefView || null,
-              editorSettings: config.editorSettings || false,
-              detailComponent: config.detailView || null,
-              aggregations: config.aggregations || null,
-              aggregationsExpand: config.aggregationsExpand || [],
-              aggregationsOrder: config.aggregationsOrder || [],
-              aggregationsBucketSize: 10,
-              files: config.files || null,
-              searchFields: config.searchFields || null,
-              recordResource: config.recordResource || null,
-              exportFormats: config.exportFormats || null,
-              sortOptions: config.sortOptions || null,
-              canAdd: () => this._can(config.type, 'add'),
-              canUpdate: (record: any) => this._can(config.type, 'update', record),
-              canDelete: (record: any) => this._can(config.type, 'delete', record),
-              canRead: (record: any) => this._can(config.type, 'read', record)
-            }
-          ]
+    this._userService.user$.subscribe((user) => {
+      if (user) {
+        /** Removes collections and subdivisions routes on the organisation shared */
+        if (!('isDedicated' in user.organisation) || !(user.organisation.isDedicated)) {
+          recordsRoutesConfiguration =  recordsRoutesConfiguration
+          .filter(route => !(['collections', 'subdivisions'].includes(route.type)));
         }
-      };
 
-      this._router.config[0].children.push(route);
+        recordsRoutesConfiguration.forEach((config: any) => {
+          const route = {
+            matcher: (url: any) => this._routeMatcher(url, config.type),
+            canActivate: [RoleGuard],
+            children: [
+              { path: '', component: RecordSearchPageComponent },
+              { path: 'detail/:pid', component: DetailComponent },
+              { path: 'edit/:pid', component: EditorComponent },
+              { path: 'new', component: EditorComponent, canActivate: [CanAddGuard] }
+            ],
+            data: {
+              role: 'submitter',
+              showSearchInput: true,
+              types: [
+                {
+                  key: config.type,
+                  label: config.label || config.type.charAt(0).toUpperCase() + config.type.slice(1),
+                  component: config.briefView || null,
+                  editorSettings: config.editorSettings || false,
+                  detailComponent: config.detailView || null,
+                  aggregations: config.aggregations || null,
+                  aggregationsExpand: config.aggregationsExpand || [],
+                  aggregationsOrder: config.aggregationsOrder || [],
+                  aggregationsBucketSize: 10,
+                  files: config.files || null,
+                  searchFields: config.searchFields || null,
+                  recordResource: config.recordResource || null,
+                  exportFormats: config.exportFormats || null,
+                  sortOptions: config.sortOptions || null,
+                  canAdd: () => this._can(config.type, 'add'),
+                  canUpdate: (record: any) => this._can(config.type, 'update', record),
+                  canDelete: (record: any) => this._can(config.type, 'delete', record),
+                  canRead: (record: any) => this._can(config.type, 'read', record)
+                }
+              ]
+            }
+          };
+
+          this._router.config[0].children.push(route);
+        });
+      }
     });
   }
 

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -16,7 +16,7 @@
  */
 import { DatePipe } from '@angular/common';
 import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -31,6 +31,7 @@ import { TooltipModule } from 'ngx-bootstrap/tooltip';
 import { NgxDropzoneModule } from 'ngx-dropzone';
 import { ToastrModule } from 'ngx-toastr';
 import { AppConfigService } from './app-config.service';
+import { AppInitializerService } from './app-initializer.service';
 import { AppRoutingModule } from './app-routing.module';
 import { AppTranslateLoader } from './app-translate-loader';
 import { AppComponent } from './app.component';
@@ -66,6 +67,10 @@ import { UserComponent } from './record/user/user.component';
 import { ValidationComponent } from './record/validation/validation.component';
 import { UserService } from './user.service';
 import { AdminComponent } from './_layout/admin/admin.component';
+
+export function appInitializerFactory(appInitializerService: AppInitializerService): () => Promise<any> {
+  return () => appInitializerService.initialize().toPromise();
+}
 
 export function minElementError(err: any, field: FormlyFieldConfig) {
   return `This field must contain at least ${field.templateOptions.minItems} element.`;
@@ -137,6 +142,15 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     {
       provide: CoreConfigService,
       useClass: AppConfigService
+    },
+    {
+      provide: APP_INITIALIZER,
+      useFactory: appInitializerFactory,
+      deps: [
+        AppInitializerService,
+        UserService
+      ],
+      multi: true
     },
     BsLocaleService,
     DatePipe

--- a/projects/sonar/src/app/user.service.ts
+++ b/projects/sonar/src/app/user.service.ts
@@ -31,23 +31,25 @@ export class UserService {
   private _user: any = null;
 
   /**
-   * Constructor.
-   *
+   * Constructor
    * @param _apiService API service.
    * @param _http HTTP client.
    */
-  constructor(private _apiService: ApiService, private _http: HttpClient) {
-    this.loadLoggedUser().subscribe();
-  }
+  constructor(private _apiService: ApiService, private _http: HttpClient) {}
 
+  /**
+   * Get user observable
+   * @return observable of user
+   */
   get user$(): Observable<any> {
     return this._userSubject.asObservable();
   }
 
   /**
    * Load logged user in backend
+   * @return Observable of user
    */
-  loadLoggedUser(resolve: boolean = true) {
+  loadLoggedUser(resolve: boolean = true): Observable<any> {
     return this._http
       .get<any>(`${this._apiService.baseUrl}/logged-user/${resolve ? '?resolve=1' : ''}`)
       .pipe(
@@ -60,6 +62,7 @@ export class UserService {
             this._user = user.metadata;
             this._userSubject.next(user.metadata);
           }
+          return user;
         })
       );
   }
@@ -100,9 +103,10 @@ export class UserService {
 
   /**
    * Check if user reference is corresonding to logged user id.
-   * @param reference User JSON endpoint reference
+   * @param reference User JSON endpoint reference.
+   * @return true if the reference is the same user.
    */
-  checkUserReference(reference: string) {
+  checkUserReference(reference: string): boolean {
     const result = /[0-9]+$/.exec(reference);
 
     if (result === null) {
@@ -114,23 +118,28 @@ export class UserService {
 
   /**
    * Check if given PID is the same as logged user.
-   * @param pid User PID to check against logged user
+   * @param pid User PID to check against logged user.
+   * @return true if logged user has the same PID.
    */
   checkUserPid(pid: string): boolean {
     return this._user.pid === pid;
   }
 
   /**
+   * Check if the current user is on dedicated organisation.
+   * @return true if the organisation is dedicated.
+   */
+  isDedecatedOrganisation(): boolean {
+    return 'isDedicated' in this._user.organisation
+      && this._user.organisation.isDedicated;
+  }
+
+  /**
    * Return the link to public interface, depending on user's organisation.
-   *
    * @returns Link to public interface.
    */
    getPublicInterfaceLink(): string {
-    if (
-      this._user &&
-      this._user.organisation &&
-      this._user.organisation.isDedicated
-    ) {
+    if (this.isDedecatedOrganisation()) {
       return `/${this._user.organisation.code}`;
     }
 


### PR DESCRIPTION
Remove the "Collections" and "Subdivisions" entries
in the administration menu for shared organizations.

* Closes rero/sonar#751.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## How to test?

- Check administration menu with user connected with shared organisation.

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
