### PR TITLE
documents: fix abstracts sort

### DIFF
--- a/projects/sonar/src/app/record/document/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/document/detail/detail.component.ts
@@ -285,6 +285,18 @@ export class DetailComponent implements OnDestroy, OnInit {
       return;
     }
 
+    const abstractsLanguage = [];
+    const abstractsCode = [];
+    this.record.abstracts.forEach((abstract: any) => {
+      if (this._configService.languagesMap.find(
+        (map: { code: string; bibCode: string }) => map.bibCode === abstract.language)
+      ) {
+        abstractsLanguage.push(abstract);
+      } else {
+        abstractsCode.push(abstract);
+      }
+    });
+
     const firstLanguage = this._configService.languagesMap.find(
       (item) => item.code === this._translateService.currentLang
     );
@@ -292,18 +304,19 @@ export class DetailComponent implements OnDestroy, OnInit {
       this._configService.languagesMap
     );
 
-    this.record.abstracts = this.record.abstracts.sort((a: any, b: any) => {
+    this.record.abstracts = abstractsLanguage.sort((a: any, b: any) => {
       const aIndex = languagesPriorities.findIndex(
         (lang) => a.language === lang.bibCode
       );
       const bIndex = languagesPriorities.findIndex(
         (lang) => b.language === lang.bibCode
       );
-
       if (aIndex === bIndex) {
         return 0;
       }
       return aIndex < bIndex ? -1 : 1;
-    });
+    }).concat(
+      abstractsCode.sort((a: any, b: any) => a.language.localeCompare(b.language))
+    );
   }
 }


### PR DESCRIPTION
The languages of the abstracts that are not in the preferred
sorting languages are added at the end of the list and sorted
alphabetically by language code.

* Fixes Sentry SONAR-EA.

Co-Authored-by: Bertrand Zuchuat <bertrand.zuchuat@rero.ch>

## Code review check list

- [ ] Commit message template compliance.
- [ ] Commit message without typos.
- [ ] File names.
- [ ] Functions names.
- [ ] Functions docstrings.
- [ ] Unnecessary commited files?
- [ ] Extracted translations?
