### PR TITLE
feat(document): add license logo and link

### DIFF
--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -97,6 +97,7 @@ import { BriefViewComponent as SubdivisionBriefViewComponent } from './record/su
 import { UserComponent } from './record/user/user.component';
 import { ValidationComponent } from './record/validation/validation.component';
 import { UserService } from './user.service';
+import { LicensePipe } from './record/document/license.pipe';
 
 export function minElementError(err: any, field: FormlyFieldConfig) {
   return `This field must contain at least ${field.templateOptions.minItems} element.`;
@@ -145,6 +146,7 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     MetadataComponent,
     FilesComponent,
     SwisscoveryComponent,
+    LicensePipe
   ],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -313,10 +313,22 @@
         [field]="record.usageAndAccessPolicy"
       >
         <ng-template let-usageAndAccessPolicy pTemplate="template">
-          {{ usageAndAccessPolicy.license | translate }}
-          @if(usageAndAccessPolicy.label) {
-          <br />{{ usageAndAccessPolicy.label }}
-          }
+          @let licenseLogo = usageAndAccessPolicy.license | license;
+          <div class="ui:flex ui:flex-col">
+            <div class="ui:flex ui:gap-2">
+              {{ usageAndAccessPolicy.license | translate }}
+              @if (licenseLogo) {
+                <a [href]="licenseLogo.link" target="_blank">
+                  <img [src]="licenseLogo.icon" [title]="usageAndAccessPolicy.license" width="73px" />
+                </a>
+              }
+            </div>
+            @if(usageAndAccessPolicy.label) {
+              <div>
+                {{ usageAndAccessPolicy.label }}
+              </div>
+            }
+          </div>
         </ng-template>
       </sonar-field-description>
 

--- a/projects/sonar/src/app/record/document/license.pipe.spec.ts
+++ b/projects/sonar/src/app/record/document/license.pipe.spec.ts
@@ -1,0 +1,37 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2025 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { LicensePipe } from './license.pipe';
+
+describe('LicensePipe', () => {
+  let pipe: LicensePipe;
+
+  beforeEach(() => {
+    pipe = new LicensePipe();
+  });
+
+  it('should return license info', () => {
+    const licenseInfo = {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nc.svg',
+      link: 'https://creativecommons.org/licenses/by-nc/4.0/'
+    };
+    expect(pipe.transform('CC BY-NC')).toEqual(licenseInfo);
+  });
+
+  it('should return null if the license is not known.', () => {
+    expect(pipe.transform('License undefined')).toBeNull();
+  });
+});

--- a/projects/sonar/src/app/record/document/license.pipe.ts
+++ b/projects/sonar/src/app/record/document/license.pipe.ts
@@ -1,0 +1,66 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2025 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'license',
+  standalone: false
+})
+export class LicensePipe implements PipeTransform {
+
+  private availableLicenses = {
+    CC0: {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg',
+      link: 'https://creativecommons.org/publicdomain/zero/1.0/'
+    },
+    'CC BY': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by.svg',
+      link: 'https://creativecommons.org/licenses/by/4.0/'
+    },
+    'CC BY-NC': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nc.svg',
+      link: 'https://creativecommons.org/licenses/by-nc/4.0/'
+    },
+    'CC BY-NC-ND': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nc-nd.svg',
+      link: 'https://creativecommons.org/licenses/by-nc-nd/4.0/'
+    },
+    'CC BY-NC-SA': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nc-sa.svg',
+      link: 'https://creativecommons.org/licenses/by-nc-sa/4.0/'
+    },
+    'CC BY-ND': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-nd.svg',
+      link: 'https://creativecommons.org/licenses/by-nd/4.0/'
+    },
+    'CC BY-SA': {
+      icon: 'https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by-sa.svg',
+      link: 'https://creativecommons.org/licenses/by-sa/4.0/'
+    },
+  };
+
+  transform(licenseKey: string): licenseType | null {
+    return Object.keys(this.availableLicenses).includes(licenseKey)
+      ? this.availableLicenses[licenseKey]
+      : null;
+  }
+}
+
+type licenseType = {
+  icon: string;
+  link: string;
+};


### PR DESCRIPTION
* Closes rero/sonar#414.

Dependencies: https://github.com/rero/sonar/pull/1019

<img width="538" height="172" alt="license" src="https://github.com/user-attachments/assets/598f9eed-5d1f-4679-af56-ef23a745f6fe" />
