### PR TITLE
feat(deposit): add validate and see other deposits button

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -512,6 +512,7 @@ export class AppRoutingModule {
                   aggregationsExpand: config.aggregationsExpand || [],
                   aggregationsOrder: config.aggregationsOrder || [],
                   aggregationsBucketSize: 10,
+                  showFacetsIfNoResults: true,
                   files: config.files || null,
                   searchFields: config.searchFields || null,
                   recordResource: config.recordResource || null,

--- a/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
@@ -86,14 +86,23 @@
     }
 
     <dl class="metadata ui:text-sm">
-      <dt>{{ 'Created by' | translate }}</dt>
+      <dt translate>Created by</dt>
       <dd>{{ record.metadata.user.first_name }} {{ record.metadata.user.last_name }}</dd>
 
-      <dt>{{ 'Created at' | translate }}</dt>
+      <dt translate>Created at</dt>
       <dd>{{ record.created | dateTranslate: 'medium' }}</dd>
 
-      <dt>{{ 'Updated at' | translate }}</dt>
+      <dt translate>Updated at</dt>
       <dd>{{ record.updated | dateTranslate: 'medium' }}</dd>
+
+      @if(canAccessToDocumentRedirect && record.metadata.document) {
+        <dt>{{ 'Document' | translate }}</dt>
+        <dd>
+          <a [routerLink]="['/records', 'documents', 'detail', record.metadata.document.pid]">
+            {{ record.metadata.metadata.title }}
+          </a>
+        </dd>
+      }
     </dl>
 
     <div class="ui:flex ui:gap-1 ui:flex-wrap">

--- a/projects/sonar/src/app/deposit/brief-view/brief-view.component.ts
+++ b/projects/sonar/src/app/deposit/brief-view/brief-view.component.ts
@@ -25,7 +25,7 @@ import { UserService } from '../../user.service';
 })
 export class BriefViewComponent implements OnInit, OnDestroy {
 
-  private _userService: UserService = inject(UserService);
+  private userService: UserService = inject(UserService);
 
   historyDialogVisible = false;
 
@@ -38,8 +38,12 @@ export class BriefViewComponent implements OnInit, OnDestroy {
   // User subscription
   private userSubscription: Subscription;
 
+  get canAccessToDocumentRedirect(): boolean {
+    return this.userService.hasRole(['moderator', 'admin', 'superuser']);
+  }
+
   ngOnInit() {
-    this.userSubscription = this._userService.user$.subscribe((user) => {
+    this.userSubscription = this.userService.user$.subscribe((user) => {
       this.user = user;
     });
   }
@@ -51,6 +55,7 @@ export class BriefViewComponent implements OnInit, OnDestroy {
   showHistoryDialog() {
     this.historyDialogVisible = true;
   }
+
   /**
    * Check if current logged user can continue to fill the deposit.
    */
@@ -62,7 +67,7 @@ export class BriefViewComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    return this._userService.checkUserPid(this.record.metadata.user.pid);
+    return this.userService.checkUserPid(this.record.metadata.user.pid);
   }
 
   /**

--- a/projects/sonar/src/app/deposit/confirmation/confirmation.component.html
+++ b/projects/sonar/src/app/deposit/confirmation/confirmation.component.html
@@ -1,6 +1,6 @@
 <!--
   SONAR User Interface
-  Copyright (C) 2021 RERO
+  Copyright (C) 2021-2025 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -15,7 +15,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
 @if(deposit$ | async; as deposit) {
-  <div class="ui:flex ui:flex-col ui:gap-2">
+  <div class="ui:flex ui:flex-col ui:gap-3">
     <p-message
       [text]="'Thank you for submitting a publication!' | translate"
       severity="success"
@@ -36,8 +36,12 @@
       />
     }
     @if(isSubmitter) {
-      <a [href]="publicInterfaceLink" translate>Back to public interface</a>
-      <a routerLink="['/deposit', 'create']" translate>Deposit another publication</a>
+      <div class="ui:flex ui:mt-4">
+        <div class="ui:grow">
+          <a [href]="publicInterfaceLink" translate>Back to public interface</a>
+        </div>
+        <a routerLink="['/deposit', 'create']" translate>Deposit another publication</a>
+      </div>
     }
   </div>
 }

--- a/projects/sonar/src/app/deposit/review/review.component.html
+++ b/projects/sonar/src/app/deposit/review/review.component.html
@@ -1,6 +1,6 @@
 <!--
   SONAR User Interface
-  Copyright (C) 2021 RERO
+  Copyright (C) 2021-2025 RERO
 
   This program is free software: you can redistribute it and/or modify
   it under the terms of the GNU Affero General Public License as published by
@@ -16,37 +16,37 @@
 -->
 @if(user && deposit && deposit.status === 'to_validate' && user.is_moderator) {
   <p-panel [header]="'Deposit review' | translate">
-      <div class="ui:flex ui:justify-center">
-    <textarea
-      class="ui:min-w-lg ui:my-4"
-      pTextarea
-      [autoResize]="true"
-      [placeholder]="'Leave a comment for the user...' | translate"
-      [(ngModel)]="comment"
-    ></textarea>
+    <div class="ui:flex ui:justify-center">
+      <textarea
+        class="ui:min-w-lg ui:my-4"
+        pTextarea
+        [autoResize]="true"
+        [placeholder]="'Leave a comment for the user...' | translate"
+        [(ngModel)]="comment"
+      ></textarea>
     </div>
     <ng-template #footer>
-      <div class="ui:flex ui:justify-center">
-        <p-buttongroup class="ui:mx-auto">
+      <div class="ui:flex ui:gap-2 ui:justify-center">
         <p-button
-          size="large"
           severity="success"
-          (onClick)="review('approve')"
-          [label]="'Approve' | translate"
+          (onClick)="review('approve', true)"
+          [label]="'Validate' | translate"
         />
         <p-button
-          size="large"
+          severity="primary"
+          (onClick)="review('approve')"
+          [label]="'Validate and see other deposits' | translate"
+        />
+        <p-button
           severity="warn"
           (onClick)="review('ask_for_changes')"
           [label]="'Ask for changes' | translate"
         />
         <p-button
-          size="large"
           severity="danger"
           (onClick)="review('reject')"
           [label]="'Reject' | translate"
         />
-      </p-buttongroup>
     </div>
     </ng-template>
 </p-panel>

--- a/projects/sonar/src/app/deposit/review/review.component.ts
+++ b/projects/sonar/src/app/deposit/review/review.component.ts
@@ -1,6 +1,6 @@
 /*
  * SONAR User Interface
- * Copyright (C) 2021 RERO
+ * Copyright (C) 2021-2025 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -22,6 +22,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { Subscription } from 'rxjs';
 import { UserService } from '../../user.service';
 import { DepositService } from '../deposit.service';
+import { validation_status } from '../../record/validation/constants';
 
 @Component({
     selector: 'sonar-deposit-review',
@@ -44,25 +45,25 @@ export class ReviewComponent implements OnInit, OnDestroy {
   user: any;
 
   // User subscription
-  private _userSubscription: Subscription;
+  private userSubscription: Subscription;
 
   /** Used to retrieve value for the comment */
   comment: string;
 
   ngOnInit() {
-    this._userSubscription = this.userService.user$.subscribe((user) => {
+    this.userSubscription = this.userService.user$.subscribe((user) => {
       this.user = user;
     });
   }
 
   ngOnDestroy() {
-    this._userSubscription.unsubscribe();
+    this.userSubscription.unsubscribe();
   }
 
   /**
    * Approve the deposit.
    */
-  review(action: string) {
+  review(action: string, edit: boolean = false): void {
       this.confirmationService.confirm({
         header: this.translateService.instant('deposit_log_action_' + action),
         message: this.translateService.instant('Do you really want to do this action?'),
@@ -78,9 +79,14 @@ export class ReviewComponent implements OnInit, OnDestroy {
               detail: this.translateService.instant('Review has been done successfully!'),
               life: CONFIG.MESSAGE_LIFE,
             });
-            this.router.navigate(['records', 'deposits'], {
-              queryParams: { q: `pid:${deposit.pid}` }
-            });
+            if (edit) {
+              const documentPid = deposit.document.$ref.split('/').pop();
+              this.router.navigate(['records', 'documents', 'detail', documentPid]);
+            } else {
+              this.router.navigate(['records', 'deposits'], {
+                queryParams: { status: validation_status.TO_VALIDATE }
+              });
+            }
           });
         }
     });

--- a/projects/sonar/src/manual_translations.ts
+++ b/projects/sonar/src/manual_translations.ts
@@ -1,6 +1,6 @@
 /*
  * SONAR User Interface
- * Copyright (C) 2021 RERO
+ * Copyright (C) 2021-2025 RERO
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -59,3 +59,11 @@ _('Organisations');
 _('Projects');
 _('Subdivisions');
 _('Users');
+
+// Status
+_('in_progress');
+_('validated');
+_('to_validate');
+_('rejected');
+_('ask_for_changes');
+


### PR DESCRIPTION
* Adds the validate and see other deposits button on the review.
* Adds the document link to deposit brief view.
* Adds all deposit status to the manual translations.
* Updates deposit config to show facets if no result.
* Enhances the display of the deposit validation.
* Closes rero/sonar#826.

### DISPLAY
<img width="1112" height="234" alt="review_buttons" src="https://github.com/user-attachments/assets/899abc60-3d8a-4490-82d0-7b40f40dffe3" />

