### PR TITLE
fix(document): fix classification and subject links

### DIFF
--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -148,7 +148,8 @@
               <p-tag severity="secondary" icon="fa fa-tag">
                 <a
                 [routerLink]="['/', 'records', 'documents']"
-                [queryParams]="{ q: 'subjects.label.value:' + value }"
+                [queryParams]="{ q: 'subjects.label.value:' + '&quot;' + value + '&quot;'}"
+
                 >
                   {{value}}
                 </a>
@@ -239,25 +240,27 @@
       />
 
       <!-- CLASSIFICATION -->
-      @if (UDCclassifications.length > 0) {
-        <sonar-field-description
-          [label]="'Classification' | translate"
-          [field]="UDCclassifications"
-        >
-          <ng-template let-classification pTemplate="template">
-            <a
-              [routerLink]="['/', 'records', 'documents']"
-              [queryParams]="{
-                q:
-                  'classification.classificationPortion:' +
-                  classification.classificationPortion
-              }"
-            >
+      <sonar-field-description
+        [label]="'Classification' | translate"
+        [field]="record.classification"
+      >
+        <ng-template let-classification pTemplate="template">
+          <a
+            [routerLink]="['/', 'records', 'documents']"
+            [queryParams]="{
+              q:
+                'classification.classificationPortion:' + '&quot;' +
+                classification.classificationPortion + '&quot;'
+            }"
+          >
+            @if (classification.type === "bf:ClassificationUdc") {
               {{ 'classification_' + classification.classificationPortion | translate }}
-            </a>
-          </ng-template>
-        </sonar-field-description>
-      }
+            } @else {
+              {{ classification.classificationPortion }}
+            }
+          </a>
+        </ng-template>
+      </sonar-field-description>
 
       <!-- OTHER EDITION -->
       <sonar-field-description

--- a/projects/sonar/src/app/record/document/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/document/detail/detail.component.ts
@@ -121,21 +121,6 @@ export class DetailComponent implements OnDestroy, OnInit {
   }
 
   /**
-   * Return the list of UDC classifications.
-   *
-   * @returns List of UDC classifications.
-   */
-  get UDCclassifications(): Array<any> {
-    if (!this.record.classification) {
-      return [];
-    }
-
-    return this.record.classification.filter((item: any) => {
-      return item.type === 'bf:ClassificationUdc';
-    });
-  }
-
-  /**
    * Scroll to target.
    *
    * @param event DOM event triggered.


### PR DESCRIPTION
* Displays the classification even if it is of type Ddc.
* Make the links to classifications and subjects more robust with quotes.
* Linked to rero/sonar#1028.