### PR TITLE
fix: remove 'Admin' entry from the admin menu

### DIFF
--- a/projects/sonar/src/app/_layout/admin/admin.component.ts
+++ b/projects/sonar/src/app/_layout/admin/admin.component.ts
@@ -178,9 +178,9 @@ export class AdminComponent implements OnInit, OnDestroy {
               url: '/users/profile',
             },
             {
-              label:  this.translateService.instant('Administration'),
-              url: '/manage',
-              visible: this.user.is_admin
+              label:  this.translateService.instant('Super administration'),
+              url: '/admin',
+              visible: this.user.is_superuser
             },
             {
               label:  this.translateService.instant('Logout'),


### PR DESCRIPTION
* This entry was not ueful since we are already in the admin interface.
* Closes rero/sonar#679.