### PR TITLE
fix: remove ark identifier from the document editor

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -275,6 +275,9 @@ export class AppRoutingModule {
         aggregationsOrder: this._documentAggregationsOrder(),
         editorSettings: {
           longMode: true,
+          getHeaders: {
+            Accept: 'application/rero+json'
+          }
         },
         files: {...fileConfig,
           filterList: (item: any) => {


### PR DESCRIPTION
Depends on: https://github.com/rero/ng-core/pull/751

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
