### PR TITLE
fix: hide "edit files" tabs if the user does not have the right permissions

### DIFF
--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -574,9 +574,14 @@ export class AppRoutingModule {
    * @param record Record dict.
    * @return Observable
    */
-  private _can(resource: string, action: string, record: any = null): Observable<ActionStatus> {
+  private _can(resource: string, action: string, record: any = null): Observable<ActionStatus | null> {
     if (resource === 'deposits' && ['add', 'update'].includes(action)) {
       return of({ can: false, message: '' });
+    }
+
+    // the delete button should be hidden not only disabled
+    if (resource === 'documents' && ['delete'].includes(action) && record.metadata.permissions[action] === false) {
+      return of(null);
     }
 
     if (record) {

--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -353,28 +353,32 @@
 </section>
 
 <!-- TABS -->
-<p-tabs value="edit">
+<p-tabs [value]="record().permissions.update ? 'edit' : 'stats'">
   <p-tablist>
-    <p-tab value="edit">
-      {{ 'Edit Files' | translate }}
-    </p-tab>
+    @if(record().permissions.update) {
+      <p-tab value="edit">
+        {{ 'Edit Files' | translate }}
+      </p-tab>
+    }
     <p-tab value="stats">
       {{ 'Statistics' | translate }}
     </p-tab>
     <p-tab value="others" [disabled]="filteredFiles().length > 1? false: true">
-      {{ 'Other files' | translate}}
+      {{ 'Other files' | translate }}
     </p-tab>
   </p-tablist>
   <p-tabpanels>
-    <p-tabpanel #editFile value="edit">
-      @if(editFile.active()) {
-        <sonar-upload-files
-          recordType="documents"
-          [pid]="record().pid"
-          (filesChanged)="updateFiles()"
-        />
-      }
-    </p-tabpanel>
+    @if(record().permissions.update) {
+      <p-tabpanel #editFile value="edit">
+        @if(editFile.active()) {
+          <sonar-upload-files
+            recordType="documents"
+            [pid]="record().pid"
+            (filesChanged)="updateFiles()"
+          />
+        }
+      </p-tabpanel>
+    }
     <p-tabpanel #stats value="stats">
       @if(stats.active()) {
         <sonar-stats-files


### PR DESCRIPTION
* Hides the delete button when a user does not have the permission to delete a document.
* Hides the "edit files" tab on the document detailed view if the user does not have the right permissions.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
