### PR TITLE
fix: the autocomplete does not work on editor

### DIFF
--- a/projects/sonar/src/app/ui-autocomplete.service.ts
+++ b/projects/sonar/src/app/ui-autocomplete.service.ts
@@ -38,8 +38,8 @@ export class UIAutocompleteService {
       return of([]);
     }
     let url = `/api/${queryOptions.type}/?q=${queryOptions.field}:${query}`;
-    if(queryOptions.type === 'documents') {
-      url = `/api/suggestions/completion?resource=${queryOptions.type}&field=${queryOptions.field}&q=${query}`;
+    if (queryOptions.suggest) {
+      url = `${queryOptions.suggest}?resource=${queryOptions.type}&field=${queryOptions.field}&q=${query}`;
     }
     return this.httpClient.get(url).pipe(
         map((results: any) => {


### PR DESCRIPTION
* Removes hard coded resource name document in the autocomplete service.

Co-Authored-by: Johnny Mariéthoz <Johnny.Mariethoz@rero.ch>
