### PR TITLE
fix(validation): restore ValidationComponent accidentally deleted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4554,8 +4554,10 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -4579,8 +4581,10 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4609,8 +4613,10 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -4622,8 +4628,10 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "extraneous": true,
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },

--- a/projects/sonar/src/app/app-routing.module.ts
+++ b/projects/sonar/src/app/app-routing.module.ts
@@ -156,7 +156,7 @@ export const typeResolver: ResolveFn<string> = (route) => {
 export class AppRoutingModule {
 
   private translateService: TranslateService = inject(TranslateService);
-  private router: Router= inject(Router);
+  private router: Router = inject(Router);
   private route: ActivatedRoute = inject(ActivatedRoute);
   private userService: UserService = inject(UserService);
   private httpClient: HttpClient = inject(HttpClient);
@@ -279,7 +279,8 @@ export class AppRoutingModule {
             Accept: 'application/rero+json'
           }
         },
-        files: {...fileConfig,
+        files: {
+          ...fileConfig,
           filterList: (item: any) => {
             return (
               item.metadata &&
@@ -396,6 +397,29 @@ export class AppRoutingModule {
         editorSettings: {
           longMode: true,
         },
+        preCreateRecord: (record: any) => {
+          const user = this.userService.currentUser();
+          // add organisation reference to the new record
+          const organisationCode = user.organisation.code;
+          if (organisationCode) {
+            record.metadata.organisation = {
+              $ref: this.apiService.getRefEndpoint(
+                'organisations',
+                organisationCode
+              )
+            };
+          }
+          const userPid = user.pid;
+          if (userPid) {
+            record.metadata.user = {
+              $ref: this.apiService.getRefEndpoint(
+                'users',
+                userPid
+              )
+            };
+          }
+          return record;
+        },
         exportFormats: [
           {
             label: 'CSV',
@@ -474,8 +498,8 @@ export class AppRoutingModule {
       if (user) {
         /** Removes collections and subdivisions routes on the organisation shared */
         if (!('isDedicated' in user.organisation) || !(user.organisation.isDedicated)) {
-          recordsRoutesConfiguration =  recordsRoutesConfiguration
-          .filter(route => !(['collections', 'subdivisions'].includes(route.type)));
+          recordsRoutesConfiguration = recordsRoutesConfiguration
+            .filter(route => !(['collections', 'subdivisions'].includes(route.type)));
         }
 
         recordsRoutesConfiguration.forEach((config: any) => {
@@ -521,6 +545,7 @@ export class AppRoutingModule {
                   recordResource: config.recordResource || null,
                   exportFormats: config.exportFormats || null,
                   sortOptions: config.sortOptions || null,
+                  preCreateRecord: config.preCreateRecord || null,
                   canAdd: () => this._can(config.type, 'add'),
                   canUpdate: (record: any) => this._can(config.type, 'update', record),
                   canDelete: (record: any) => this._can(config.type, 'delete', record),
@@ -634,7 +659,7 @@ export class AppRoutingModule {
   private _documentAggregationsOrder(): Observable<any> {
     return of(null).pipe(
       switchMap(() => {
-        const {view} = this.route.snapshot.children[0].params;
+        const { view } = this.route.snapshot.children[0].params;
 
         let params = new HttpParams();
         if (view) {

--- a/projects/sonar/src/app/app.module.ts
+++ b/projects/sonar/src/app/app.module.ts
@@ -95,6 +95,7 @@ import { BriefViewComponent as ProjectBriefViewComponent } from './record/projec
 import { DetailComponent as ProjectDetailComponent } from './record/project/detail/detail.component';
 import { BriefViewComponent as SubdivisionBriefViewComponent } from './record/subdivision/brief-view/brief-view.component';
 import { UserComponent } from './record/user/user.component';
+import { ValidationComponent } from './record/validation/validation.component';
 import { UserService } from './user.service';
 import { LicensePipe } from './record/document/license.pipe';
 import { BucketNameService } from './bucket-name.service';
@@ -145,7 +146,8 @@ export function minElementError(err: any, field: FormlyFieldConfig) {
     MetadataComponent,
     FilesComponent,
     SwisscoveryComponent,
-    LicensePipe
+    LicensePipe,
+    ValidationComponent
   ],
   bootstrap: [AppComponent],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],

--- a/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/deposit/brief-view/brief-view.component.html
@@ -62,22 +62,8 @@
       @if(!record.metadata.logs || record.metadata.logs.length === 1) {
         <p-tag severity="contrast" [value]="'New' | translate" />
       }
-      @switch(record.metadata.status) {
-        @case('in_progress') {
-          <p-tag severity="primary" [value]="('deposit_status_' + record.metadata.status) | translate" />
-        }
-        @case('to_validate') {
-          <p-tag severity="info" [value]="('deposit_status_' + record.metadata.status) | translate" />
-        }
-        @case('ask_for_changes') {
-          <p-tag severity="warn" [value]="('deposit_status_' + record.metadata.status) | translate" />
-        }
-        @case('validated') {
-          <p-tag severity="success" [value]="('deposit_status_' + record.metadata.status) | translate" />
-        }
-        @case('rejected') {
-          <p-tag severity="danger" [value]="('deposit_status_' + record.metadata.status) | translate" />
-        }
+      @if(statusSeverity) {
+        <p-tag [severity]="statusSeverity" [value]="('deposit_status_' + record.metadata.status) | translate" />
       }
     </div>
 

--- a/projects/sonar/src/app/deposit/brief-view/brief-view.component.ts
+++ b/projects/sonar/src/app/deposit/brief-view/brief-view.component.ts
@@ -16,6 +16,7 @@
  */
 import { Component, computed, inject, OnDestroy, OnInit, signal } from '@angular/core';
 import { Subscription } from 'rxjs';
+import { VALIDATION_STATUS_SEVERITY } from '../../enum/validation';
 import { UserService } from '../../user.service';
 
 @Component({
@@ -47,6 +48,12 @@ export class BriefViewComponent implements OnInit, OnDestroy {
   canAccessToDocumentRedirect = computed(() =>
     this.userService.hasRole(['moderator', 'admin', 'superuser'])
   );
+
+  get statusSeverity(): string | null {
+    return this.record?.metadata?.status
+      ? VALIDATION_STATUS_SEVERITY[this.record.metadata.status]
+      : null;
+  }
 
   private subscription: Subscription = new Subscription();
 

--- a/projects/sonar/src/app/enum/validation.ts
+++ b/projects/sonar/src/app/enum/validation.ts
@@ -30,3 +30,11 @@ export enum validation_action {
   'REJECT' = 'reject',
   'ASK_FOR_CHANGES' = 'ask_for_changes'
 }
+
+export const VALIDATION_STATUS_SEVERITY: Record<string, string> = {
+  [validation_status.IN_PROGRESS]: 'primary',
+  [validation_status.TO_VALIDATE]: 'info',
+  [validation_status.ASK_FOR_CHANGES]: 'warn',
+  [validation_status.VALIDATED]: 'success',
+  [validation_status.REJECTED]: 'danger'
+};

--- a/projects/sonar/src/app/record/project/brief-view/brief-view.component.html
+++ b/projects/sonar/src/app/record/project/brief-view/brief-view.component.html
@@ -21,8 +21,8 @@
   </h5>
   <div class="ui:flex ui:gap-1">
     <p-tag [value]="record.metadata.organisation.name" />
-    @if(record.metadata?.validation?.status !== validationStatus.VALIDATED) {
-      <p-tag severity="warn" [value]="'This record is not published' | translate" />
+    @if(validationSeverity) {
+      <p-tag [severity]="validationSeverity" [value]="record.metadata.validation.status | translate" />
     }
   </div>
   <span>

--- a/projects/sonar/src/app/record/project/brief-view/brief-view.component.ts
+++ b/projects/sonar/src/app/record/project/brief-view/brief-view.component.ts
@@ -16,16 +16,13 @@
  */
 import { Component } from '@angular/core';
 import { ResultItem } from '@rero/ng-core';
-import { validation_status } from '../../../enum/validation';
+import { VALIDATION_STATUS_SEVERITY } from '../../../enum/validation';
 
 @Component({
     templateUrl: './brief-view.component.html',
     standalone: false
 })
 export class BriefViewComponent implements ResultItem {
-  // Constant for validation status.
-  readonly validationStatus = validation_status;
-
   // Record data.
   record: any;
 
@@ -34,4 +31,10 @@ export class BriefViewComponent implements ResultItem {
 
   // Detail URL object.
   detailUrl: { link: string, external: boolean };
+
+  get validationSeverity(): string | null {
+    return this.record?.metadata?.validation?.status
+      ? VALIDATION_STATUS_SEVERITY[this.record.metadata.validation.status]
+      : null;
+  }
 }

--- a/projects/sonar/src/app/record/validation/validation.component.html
+++ b/projects/sonar/src/app/record/validation/validation.component.html
@@ -1,0 +1,106 @@
+<!--
+  SONAR User Interface
+  Copyright (C) 2021 RERO
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License as published by
+  the Free Software Foundation, version 3 of the License.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+-->
+@if(validation && user && (isModerator() || isOwner())) {
+  <p-panel [header]="'Validation' | translate">
+    <div class="ui:flex ui:flex-col ui:gap-2 ui:justify-center ui:p-2">
+    @if(validation.status === validationStatus.IN_PROGRESS || validation.status === validationStatus.ASK_FOR_CHANGES) {
+      <p-message class="ui:w-full" severity="warn" showTransitionOptions="0ms">
+        {{ "The record is currently in status \"\{\{ status \}\}\"." | translate: { status: (validation.status) | translate } }}
+        @if(isOwner()) {
+          &nbsp;<a href="#" class="alert-link" (click)="$event.preventDefault(); updateValidation(validationAction.PUBLISH)" translate>
+            Submit it
+          </a>.
+        }
+      </p-message>
+    }
+    @if(validation.status === validationStatus.TO_VALIDATE) {
+      <p-message class="ui:w-full" severity="warn" showTransitionOptions="0ms">
+        {{"The record is in validation. It will be reviewed by a moderator before publishing." | translate}}
+      </p-message>
+    }
+    @if(validation.status === validationStatus.REJECTED) {
+      <p-message class="ui:w-full" severity="error" showTransitionOptions="0ms">
+        {{ "The record has been rejected after a review from a moderator." | translate}}
+      </p-message>
+    }
+    @if(validation.status === validationStatus.VALIDATED) {
+      <p-message class="ui:w-full" severity="success" showTransitionOptions="0ms">
+        {{ "The record is published." | translate }}
+      </p-message>
+
+    }
+    @if(validation.status === validationStatus.TO_VALIDATE && isModerator()) {
+      <textarea
+        #comment
+        class="ui:min-w-lg ui:my-4"
+        pTextarea
+        [autoResize]="true"
+        [placeholder]="'Leave a comment...' | translate"
+      ></textarea>
+      <div class="ui:flex ui:justify-center">
+        <p-buttongroup class="ui:mx-auto">
+          <p-button
+            size="large"
+            severity="success"
+            (onClick)="updateValidation(validationAction.APPROVE)"
+            [label]="'Approve' | translate"
+          />
+          <p-button
+            size="large"
+            severity="warn"
+            (onClick)="updateValidation(validationAction.ASK_FOR_CHANGES)"
+            [label]="'Ask for changes' | translate"
+          />
+          <p-button
+            size="large"
+            severity="danger"
+            (onClick)="updateValidation(validationAction.REJECT)"
+            [label]="'Reject' | translate"
+          />
+        </p-buttongroup>
+      </div>
+    }
+    @if(validation.logs) {
+    <p-button
+      [text]="true"
+      [label]="(showLogs ? 'Hide logs' : 'Show logs') | translate"
+      (onClick)="showLogs = !showLogs"
+    />
+        @if(showLogs) {
+        <p-table [value]="validation.logs" [tableStyle]="{ 'min-width': '50rem' }">
+          <ng-template #header>
+            <tr>
+              <th translate>Status</th>
+              <th translate>Date</th>
+              <th translate>User</th>
+              <th translate>Comment</th>
+            </tr>
+          </ng-template>
+          <ng-template #body let-log>
+            <tr>
+              <td>{{ (log.status) | translate }}</td>
+              <td>{{ log.date | dateTranslate: 'medium' }}</td>
+              <td>{{ log.user.name }}</td>
+              <td [innerHtml]="log.comment | nl2br"></td>
+            </tr>
+          </ng-template>
+        </p-table>
+      }
+    }
+    </div>
+  </p-panel>
+}

--- a/projects/sonar/src/app/record/validation/validation.component.ts
+++ b/projects/sonar/src/app/record/validation/validation.component.ts
@@ -1,0 +1,132 @@
+/*
+ * SONAR User Interface
+ * Copyright (C) 2021 RERO
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+import { Component, ElementRef, inject, Input, OnInit, ViewChild } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { CONFIG, RecordService } from '@rero/ng-core';
+import { NgxSpinnerService } from 'ngx-spinner';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { UserService } from '../../user.service';
+import { validation_action, validation_status } from '../../enum/validation';
+
+/**
+ * Component to manage validation on a record.
+ */
+@Component({
+  selector: 'sonar-record-validation',
+  templateUrl: './validation.component.html',
+  standalone: false,
+})
+export class ValidationComponent implements OnInit {
+
+  private userService: UserService = inject(UserService);
+  private recordService: RecordService = inject(RecordService);
+  private translateService: TranslateService = inject(TranslateService);
+  private messageService: MessageService = inject(MessageService);
+  private confirmationService: ConfirmationService = inject(ConfirmationService);
+  private spinner: NgxSpinnerService = inject(NgxSpinnerService);
+
+  // Constant for validation status.
+  readonly validationStatus = validation_status;
+
+  // Constant for validation actions.
+  readonly validationAction = validation_action;
+
+  // Record object.
+  @Input() record: any;
+
+  // Resource type.
+  @Input() type: string;
+
+  // Current logged user.
+  user: any;
+
+  // Validation metadata of the record.
+  validation: any;
+
+  // Whether to show logs table or not.
+  showLogs = false;
+
+  /** Used to retrieve value for the comment */
+  @ViewChild('comment') comment: ElementRef;
+
+  ngOnInit(): void {
+    this.validation = this.record.metadata.validation;
+
+    this.userService.user$.subscribe((user) => {
+      this.user = user;
+    });
+  }
+
+  /**
+   * Check if current user is the creator of the record.
+   *
+   * @returns True if current user is the creator of the record.
+   */
+  isOwner(): boolean {
+    return this.userService.getUserRefEndpoint() === this.validation.user.$ref;
+  }
+
+  /**
+   * Check if current user is moderator.
+   *
+   * @returns True if current user is moderator.
+   */
+  isModerator(): boolean {
+    return this.user?.is_moderator ?? false;
+  }
+
+  /**
+   * Update the validation, depending on the action.
+   *
+   * @param action Action done.
+   */
+  updateValidation(action: string): void {
+    this.confirmationService.confirm({
+      header: this.translateService.instant('validation_action_' + action),
+      message: this.translateService.instant(
+        'Do you really want to do this action?'
+      ),
+      closable: false,
+      rejectButtonStyleClass: 'p-button-text',
+      accept: () => {
+        this.spinner.show();
+
+        this.validation.action = action;
+
+        // Store the comment
+        if (this.comment && this.comment.nativeElement.value) {
+          this.validation.comment = this.comment.nativeElement.value;
+        } else {
+          delete this.validation.comment;
+        }
+
+        this.recordService
+          .update(this.type, this.record.id, this.record)
+          .subscribe((record: any) => {
+            this.record = record;
+            this.validation = this.record.metadata.validation;
+            this.spinner.hide();
+            this.messageService.add({
+              severity: 'success',
+              detail: this.translateService.instant('Review has been done successfully!'),
+              life: CONFIG.MESSAGE_LIFE,
+            });
+          });
+      },
+    });
+  }
+}

--- a/projects/sonar/src/app/user.service.ts
+++ b/projects/sonar/src/app/user.service.ts
@@ -135,6 +135,10 @@ export class UserService {
       && this._user.organisation.isDedicated;
   }
 
+  currentUser(): any {
+    return this._user;
+  }
+
   /**
    * Return the link to public interface, depending on user's organisation.
    * @returns Link to public interface.


### PR DESCRIPTION
The ValidationComponent was removed in commit https://github.com/rero/sonar-ui/commit/ced084f5b2c32be9f7cb0acef38aaed0c1a2bf95 during
the signal refactoring. This component is required for the project
validation workflow in HEPVS.

- Restore validation.component.ts and validation.component.html
- Update import path for enums (./constants -> ../../enum/validation)
- Add ValidationComponent to app.module.ts declarations
- Extract validation status to severity mapping into a shared constant
  VALIDATION_STATUS_SEVERITY in validation.ts. Use getter properties in
  both project and deposit brief-view components to simplify templates
  and centralize the status-to-severity logic.
- Adds the current user organisation information when a new project is created.
- Adds a new method to return the current user organisation to the user service.
- Force ngx-formly to version 7.0.0 to prevent issues with arrays.