### PR TITLE
fix(documents): show the full-text toggle even without a query

### DIFF
--- a/projects/sonar/src/app/app.routes.ts
+++ b/projects/sonar/src/app/app.routes.ts
@@ -143,8 +143,10 @@ export const routes: Routes = [
           aggregationsExpand: ['document_type', 'controlled_affiliation', 'year'],
           aggregationsBucketSize: 10,
           exportFormats: [],
-          searchFields: [{ label: _('Search in full-text'), path: 'fulltext' }],
-          searchFilters: [{ label: _('Open access'), filter: 'open_access', value: 'true' }],
+          searchFilters: [
+            { label: _('Search in full-text'), filter: 'fulltext', value: 'true' },
+            { label: _('Open access'), filter: 'open_access', value: 'true' },
+          ],
           sortOptions: [
             { label: _('Relevance'), value: 'relevance', icon: 'fa fa-sort-amount-desc', defaultQuery: true },
             { label: _('Date descending'), value: 'newest', icon: 'fa fa-sort-amount-desc', defaultNoQuery: true },

--- a/projects/sonar/src/app/routes/documents-route.ts
+++ b/projects/sonar/src/app/routes/documents-route.ts
@@ -74,8 +74,10 @@ export const documentsRouteResolver: ResolveFn<Partial<RecordType>[]> = (route: 
         ...fileConfig,
         filterList: (item: NgCoreFile) => item.metadata?.type === 'file',
       },
-      searchFields: [{ label: _('Search in full-text'), path: 'fulltext' }],
-      searchFilters: [{ label: _('Open access'), filter: 'open_access', value: 'true' }],
+      searchFilters: [
+        { label: _('Search in full-text'), filter: 'fulltext', value: 'true' },
+        { label: _('Open access'), filter: 'open_access', value: 'true' },
+      ],
       showFacetsIfNoResults: true,
       exportFormats: [],
       sortOptions: [


### PR DESCRIPTION
Move full-text search from a `searchField` to a `searchFilter`, so the toggle is displayed regardless of the query and its state is carried through the URL. Requires the matching backend change reading the `fulltext` query argument.

Closes rero/sonar#671
Depends on https://github.com/rero/ng-core/pull/823