### PR TITLE
feat(translate): allow language config override

### DIFF
--- a/.github/workflows/continuous-integration-test.yml
+++ b/.github/workflows/continuous-integration-test.yml
@@ -12,14 +12,52 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+
       - name: Use Node.js 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
+
+      - name: Read ng-core ref
+        id: ng_core
+        run: |
+          VALUE=$(cat .ng-core-ref 2>/dev/null | grep -v '^#' | tr -d '[:space:]')
+          VALUE=${VALUE:-published}
+          if [ "$VALUE" = "published" ]; then
+            echo "local=false" >> $GITHUB_OUTPUT
+          else
+            echo "local=true" >> $GITHUB_OUTPUT
+            # support owner/repo@ref or plain ref (defaults to rero/ng-core)
+            if [[ "$VALUE" == *"@"* ]]; then
+              echo "repository=${VALUE%@*}" >> $GITHUB_OUTPUT
+              echo "ref=${VALUE#*@}" >> $GITHUB_OUTPUT
+            else
+              echo "repository=rero/ng-core" >> $GITHUB_OUTPUT
+              echo "ref=$VALUE" >> $GITHUB_OUTPUT
+            fi
+          fi
+
       - name: install package
         run: |
           npm install -g @angular/cli@21
           npm ci
+
+      - name: Checkout ng-core
+        if: steps.ng_core.outputs.local == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ steps.ng_core.outputs.repository }}
+          path: ng-core
+          ref: ${{ steps.ng_core.outputs.ref }}
+          persist-credentials: false
+
+      - name: Build and install local ng-core
+        if: steps.ng_core.outputs.local == 'true'
+        run: |
+          npm ci --prefix ng-core
+          npm run pack --prefix ng-core
+          npm i --no-save ng-core/dist/rero/ng-core
+
       - name: run tests
         run: |
           ./run-tests.sh

--- a/.ia/project-context.md
+++ b/.ia/project-context.md
@@ -25,3 +25,12 @@ This project is in active migration from Angular 19 to Angular 21 patterns:
 - Prefer pure functions for reusable logic.
 - Angular components should remain thin and focused on UI.
 
+## Git commit conventions
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+- Format: `type(scope): description`
+- **Title**: 50 characters maximum
+- **Body lines**: 72 characters maximum
+- **Body bullet points**: use `*` (asterisk), not `-` (dash)
+- Common types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `style`

--- a/.ng-core-ref
+++ b/.ng-core-ref
@@ -1,0 +1,5 @@
+# Supported formats:
+#   published                    — use published npm version (default, staging)
+#   feat/my-branch               — branch on rero/ng-core
+#   owner/ng-core@branch-or-sha  — fork + branch or SHA
+staging

--- a/angular.json
+++ b/angular.json
@@ -25,7 +25,17 @@
             "tsConfig": "projects/sonar/tsconfig.app.json",
             "assets": [
               "projects/sonar/src/favicon.ico",
-              "projects/sonar/src/assets"
+              "projects/sonar/src/assets",
+              {
+                "glob": "**/*",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/i18n",
+                "output": "/assets/sonar-ui/ng-core/i18n"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/@rero/ng-core/src/lib/translate/languages",
+                "output": "/assets/sonar-ui/ng-core/languages"
+              }
             ],
             "styles": [
               "projects/sonar/src/styles.scss"

--- a/projects/sonar/src/app/_layout/admin/admin.component.ts
+++ b/projects/sonar/src/app/_layout/admin/admin.component.ts
@@ -3,18 +3,16 @@
 import { HttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, effect, inject, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { filter } from 'rxjs/operators';
-import { TranslateService, TranslateDirective, TranslatePipe } from '@ngx-translate/core';
-import { TranslateLanguageService } from '@rero/ng-core';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet } from '@angular/router';
+import { TranslateDirective, TranslatePipe, TranslateService } from '@ngx-translate/core';
 import { NgxSpinnerService } from 'ngx-spinner';
 import { MenuItem } from 'primeng/api';
-import { AppConfigService } from '../../app-config.service';
-import { AppStore, AppStoreType } from '../../store/app.store';
-import { User } from '../../models';
-import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet } from '@angular/router';
 import { Bind } from 'primeng/bind';
 import { Menubar } from 'primeng/menubar';
 import { Message } from 'primeng/message';
+import { filter } from 'rxjs/operators';
+import { User } from '../../models';
+import { AppStore, AppStoreType } from '../../store/app.store';
 
 @Component({
     selector: 'sonar-layout-admin',
@@ -34,11 +32,8 @@ export class AdminComponent {
 
   private readonly spinner = inject(NgxSpinnerService);
   private readonly store = inject(AppStore) as AppStoreType;
-  private readonly configService = inject(AppConfigService);
   private readonly httpClient = inject(HttpClient);
   private readonly translateService = inject(TranslateService);
-  private readonly translateLanguageService = inject(TranslateLanguageService);
-
   private readonly router = inject(Router);
   private readonly activatedRoute = inject(ActivatedRoute);
 
@@ -91,6 +86,7 @@ export class AdminComponent {
       return;
     }
     const isDedicated = this.store.isDedicatedOrganisation();
+    const availableLanguages = this.store.availableLanguages();
 
     this.items.set([
       {
@@ -123,7 +119,7 @@ export class AdminComponent {
         label: `${user.last_name}, ${user.first_name}`,
         icon: 'fa-solid fa-user',
         items: [
-          { label: this.translateService.instant('Public interface'), icon: 'fa-solid fa-users', url: this.store.getPublicInterfaceLink(), target: 'public' },
+          { label: this.translateService.instant('Public interface'), icon: 'fa-solid fa-users', url: this.store.publicInterfaceLink(), target: 'public' },
           { label: this.translateService.instant('Profile'), icon: 'fa-solid fa-address-card', url: '/users/profile', target: '_self' },
           { label: this.translateService.instant('Super administration'), icon: 'fa-solid fa-screwdriver-wrench', url: '/admin', visible: user.is_superuser, target: 'admin' },
           { label: this.translateService.instant('Logout'), icon: 'fa-solid fa-right-from-bracket', url: '/logout', target: '_self' },
@@ -132,8 +128,8 @@ export class AdminComponent {
       {
         label: this.translateService.getCurrentLang().toUpperCase(),
         icon: 'fa-solid fa-language',
-        items: this.configService.languagesMap.map((lang) => ({
-          label: this.translateLanguageService.translate(lang.bibCode),
+        items: availableLanguages.map((lang) => ({
+          label: this.translateService.instant(lang.name),
           command: () => this.changeLanguage(lang.code),
         })),
       },

--- a/projects/sonar/src/app/app-config.service.ts
+++ b/projects/sonar/src/app/app-config.service.ts
@@ -10,7 +10,7 @@ import { environment } from '../environments/environment';
 export class AppConfigService extends CoreConfigService {
 
   // Current view code
-  view: string | null;
+  view: string | null = null;
 
   globalviewName: string;
 
@@ -37,7 +37,7 @@ export class AppConfigService extends CoreConfigService {
     },
   ];
 
-  settings: { document_identifier_link: unknown } | null;
+  settings: { document_identifier_link: unknown } | null = null;
 
   /**
    * Constructor.
@@ -48,9 +48,9 @@ export class AppConfigService extends CoreConfigService {
     this.apiBaseUrl = environment.apiBaseUrl;
     this.$refPrefix = environment.$refPrefix;
     this.globalviewName = environment.globalViewName;
-    this.languages = environment.languages;
     this.projectTitle = environment.projectTitle;
     this.schemaFormEndpoint = '/schemas';
     this.translationsURLs = environment.translationsURLs;
+    this.ngCoreAssetsUrl = environment.ngCoreAssetsUrl ?? '';
   }
 }

--- a/projects/sonar/src/app/app-translate-loader.spec.ts
+++ b/projects/sonar/src/app/app-translate-loader.spec.ts
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { TestBed } from '@angular/core/testing';
+import { CoreConfigService, CoreTranslateLoader } from '@rero/ng-core';
+import { AppConfigService } from './app-config.service';
+import { AppTranslateLoader } from './app-translate-loader';
+
+describe('AppTranslateLoader', () => {
+  it('should be a subclass of CoreTranslateLoader', () => {
+    expect(AppTranslateLoader.prototype).toBeInstanceOf(CoreTranslateLoader);
+  });
+
+  describe('ngCoreI18n loaders', () => {
+    let loader: AppTranslateLoader;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          AppTranslateLoader,
+          { provide: CoreConfigService, useClass: AppConfigService }
+        ]
+      });
+      loader = TestBed.inject(AppTranslateLoader);
+    });
+
+    afterEach(() => vi.restoreAllMocks());
+
+    const cases = [
+      { lang: 'de', data: { greeting: 'Hallo' } },
+      { lang: 'fr', data: { greeting: 'Bonjour' } },
+      { lang: 'it', data: { greeting: 'Ciao' } },
+    ] as const;
+
+    it.each(cases)('$lang loader fetches from sonar-ui ng-core assets', async ({ lang, data }) => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(data),
+      } as Response);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (loader as any).coreTranslationLoaders[lang]();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/assets/sonar-ui/ng-core/i18n/${lang}.json`)
+      );
+      expect(result).toEqual({ default: data });
+    });
+
+    it.each(cases)('$lang loader returns empty object on HTTP error', async ({ lang }) => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (loader as any).coreTranslationLoaders[lang]();
+
+      expect(result).toEqual({ default: {} });
+    });
+
+    it.each(cases)('$lang loader returns empty object on network failure', async ({ lang }) => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = await (loader as any).coreTranslationLoaders[lang]();
+
+      expect(result).toEqual({ default: {} });
+    });
+  });
+});

--- a/projects/sonar/src/app/app-translate-loader.ts
+++ b/projects/sonar/src/app/app-translate-loader.ts
@@ -1,47 +1,32 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { inject, Injectable } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
-import { CoreTranslateLoader as NgCoreTranslateLoader } from '@rero/ng-core';
-import { combineLatest, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { AppConfigService } from './app-config.service';
-import { AppStore } from './store/app.store';
-import { UserOrganisation } from './models';
+import { CORE_TRANSLATION_LOADERS, CoreConfigService, CoreTranslateLoader, TranslationLoaderFn } from '@rero/ng-core';
 
-@Injectable({
-  providedIn: 'root',
-})
-export class AppTranslateLoader extends NgCoreTranslateLoader {
+const ngCoreI18n = (base: string, lang: string): TranslationLoaderFn =>
+  () => fetch(`${base}/assets/sonar-ui/ng-core/i18n/${lang}.json`)
+    .then(r => {
+      if (!r.ok) {
+        throw new Error(`Failed to load ${lang} translations: ${r.status}`);
+      }
+      return r.json();
+    })
+    .then((data: Record<string, string>) => ({ default: data }))
+    .catch((error: unknown) => {
+      console.error(error);
+      return { default: {} };
+    });
 
-  protected coreConfigService: AppConfigService = inject(AppConfigService);
-  private readonly store = inject(AppStore);
-  private readonly organisation$ = toObservable(this.store.organisation);
-
-  getTranslation(lang: string): Observable<Record<string, string>> {
-    const sources: [Observable<UserOrganisation | null>, Observable<Record<string, string>>] = [
-      this.organisation$,
-      super.getTranslation(lang) as Observable<Record<string, string>>,
-    ];
-    return combineLatest(sources).pipe(
-      map(([organisation, translation]) => {
-        if (organisation) {
-          const bibLanguage = this.coreConfigService.languagesMap.find(
-            (mapping: {code: string, bibCode: string}) => mapping.code === lang
-          )?.bibCode;
-          [1, 2, 3].forEach((id: number) => {
-            const key = `documentsCustomField${id}`;
-            if ((key in organisation) && ('label' in (organisation[key] as Record<string, unknown>))) {
-              const { label } = organisation[key] as { label: { language: string; value: string }[] };
-              const entry = label.find((lab) => lab.language === bibLanguage);
-              const value = entry ? entry.value : label[0].value;
-              translation[`Custom field ${id}`] = value;
-              translation[`customField${id}`] = value;
-            }
-          });
-        }
-        return translation;
-      })
-    );
+@Injectable()
+export class AppTranslateLoader extends CoreTranslateLoader {
+  constructor() {
+    super();
+    const base = inject(CoreConfigService).ngCoreAssetsUrl ?? '';
+    this.coreTranslationLoaders = {
+      ...CORE_TRANSLATION_LOADERS,
+      de: ngCoreI18n(base, 'de'),
+      fr: ngCoreI18n(base, 'fr'),
+      it: ngCoreI18n(base, 'it'),
+    };
   }
 }

--- a/projects/sonar/src/app/app-translate.service.spec.ts
+++ b/projects/sonar/src/app/app-translate.service.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
+import { NgCoreTranslateService } from '@rero/ng-core';
+import { de } from 'primelocale/js/de.js';
+import { fr } from 'primelocale/js/fr.js';
+import { it as itLocale } from 'primelocale/js/it.js';
+import { AppTranslateService } from './app-translate.service';
+
+describe('AppTranslateService', () => {
+  it('should be a subclass of NgCoreTranslateService', () => {
+    expect(AppTranslateService.prototype).toBeInstanceOf(NgCoreTranslateService);
+  });
+
+  it('should declare locale data for de, fr and it', () => {
+    expect(localeDe).toBeDefined();
+    expect(localeFr).toBeDefined();
+    expect(localeIt).toBeDefined();
+    expect(de).toBeDefined();
+    expect(fr).toBeDefined();
+    expect(itLocale).toBeDefined();
+  });
+
+});

--- a/projects/sonar/src/app/app-translate.service.ts
+++ b/projects/sonar/src/app/app-translate.service.ts
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import localeDe from '@angular/common/locales/de';
+import localeFr from '@angular/common/locales/fr';
+import localeIt from '@angular/common/locales/it';
+import { Injectable } from '@angular/core';
+import { CORE_LOCALES, Locales, NgCoreTranslateService } from '@rero/ng-core';
+import { de } from 'primelocale/js/de.js';
+import { fr } from 'primelocale/js/fr.js';
+import { it } from 'primelocale/js/it.js';
+
+@Injectable({ providedIn: 'root' })
+export class AppTranslateService extends NgCoreTranslateService {
+  override locales: Locales = {
+    ...CORE_LOCALES,
+    de: { angular: localeDe, primeng: de },
+    fr: { angular: localeFr, primeng: fr },
+    it: { angular: localeIt, primeng: it },
+  };
+}

--- a/projects/sonar/src/app/app.config.ts
+++ b/projects/sonar/src/app/app.config.ts
@@ -5,10 +5,11 @@ import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptorsFromDi } from '@a
 import { ApplicationConfig, inject, provideAppInitializer, provideZonelessChangeDetection } from '@angular/core';
 import { provideRouter, withRouterConfig } from '@angular/router';
 import { provideTranslateLoader, provideTranslateService } from '@ngx-translate/core';
-import { CoreConfigService, provideCore, RemoteAutocompleteService } from '@rero/ng-core';
+import { CoreConfigService, NgCoreTranslateService, provideCore, RemoteAutocompleteService } from '@rero/ng-core';
 import { providePrimeNG } from 'primeng/config';
 import { AppConfigService } from './app-config.service';
 import { AppTranslateLoader } from './app-translate-loader';
+import { AppTranslateService } from './app-translate.service';
 import { AppStore } from './store/app.store';
 import { HttpInterceptor } from './interceptor/http.interceptor';
 import { LanguageValuePipe } from './pipe/language-value.pipe';
@@ -24,6 +25,7 @@ export const appConfig: ApplicationConfig = {
     provideTranslateService({
       loader: provideTranslateLoader(AppTranslateLoader),
     }),
+    { provide: NgCoreTranslateService, useExisting: AppTranslateService },
     providePrimeNG(primeNGSonarConfig),
     provideHttpClient(withInterceptorsFromDi()),
     {

--- a/projects/sonar/src/app/deposit/confirmation/confirmation.component.ts
+++ b/projects/sonar/src/app/deposit/confirmation/confirmation.component.ts
@@ -57,6 +57,6 @@ export class ConfirmationComponent {
    * @returns Link to public interface.
    */
    get publicInterfaceLink(): string {
-    return this.store.getPublicInterfaceLink();
+    return this.store.publicInterfaceLink();
   }
 }

--- a/projects/sonar/src/app/deposit/deposit.service.ts
+++ b/projects/sonar/src/app/deposit/deposit.service.ts
@@ -42,7 +42,7 @@ export class DepositService {
   create(): Observable<{ metadata: Deposit; [key: string]: unknown }> {
     return this.httpClient.post<{ metadata: Deposit; [key: string]: unknown }>(`${this.apiService.getEndpointByType('deposits', true)}/`, {
       user: {
-        $ref: this.store.getUserRefEndpoint()
+        $ref: this.store.userRefEndpoint()
       },
       step: 'metadata',
       status: 'in_progress'
@@ -111,7 +111,7 @@ export class DepositService {
     return this.httpClient
       .post(`${this.depositEndPoint}/${deposit.pid}/review`, {
         action,
-        user: { $ref: this.store.getUserRefEndpoint() },
+        user: { $ref: this.store.userRefEndpoint() },
         comment: comment || null
       })
       .pipe(catchError(err => this._handleError(err)));

--- a/projects/sonar/src/app/record/validation/validation.component.ts
+++ b/projects/sonar/src/app/record/validation/validation.component.ts
@@ -77,7 +77,7 @@ export class ValidationComponent {
     );
   });
   isOwner = computed(() =>
-    this.store.getUserRefEndpoint() === (this.validation()?.['user'] as Record<string, unknown>)?.['$ref']
+    this.store.userRefEndpoint() === (this.validation()?.['user'] as Record<string, unknown>)?.['$ref']
   );
 
   constructor() {

--- a/projects/sonar/src/app/store/app.store.spec.ts
+++ b/projects/sonar/src/app/store/app.store.spec.ts
@@ -54,7 +54,7 @@ describe('AppStore', () => {
       expect(store.user()).toBeNull();
       expect(store.organisation()).toBeNull();
       expect(store.permissions()).toBeNull();
-      expect(store.settings()).toBeNull();
+      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [] });
     });
 
     it('isLogged should be false initially', () => {
@@ -81,7 +81,7 @@ describe('AppStore', () => {
       });
 
       expect(store.user()).toBeNull();
-      expect(store.settings()).toBeNull();
+      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [] });
     });
 
     it('should store settings even when user is not logged in', () => {
@@ -210,23 +210,23 @@ describe('AppStore', () => {
     });
   });
 
-  describe('getUserRefEndpoint()', () => {
+  describe('userRefEndpoint()', () => {
     it('should return the user ref endpoint', () => {
       store.load().subscribe();
       httpTesting.expectOne('/api/logged-user/?resolve=1').flush(loggedUserResponse);
-      expect(store.getUserRefEndpoint()).toBe('/api/users/1');
+      expect(store.userRefEndpoint()).toBe('/api/users/1');
     });
   });
 
-  describe('getPublicInterfaceLink()', () => {
+  describe('publicInterfaceLink()', () => {
     it('should return "/" when organisation is null', () => {
-      expect(store.getPublicInterfaceLink()).toBe('/');
+      expect(store.publicInterfaceLink()).toBe('/');
     });
 
     it('should return "/" when organisation is not dedicated', () => {
       store.load().subscribe();
       httpTesting.expectOne('/api/logged-user/?resolve=1').flush(loggedUserResponse);
-      expect(store.getPublicInterfaceLink()).toBe('/');
+      expect(store.publicInterfaceLink()).toBe('/');
     });
 
     it('should return "/<code>" when organisation is dedicated', () => {
@@ -238,7 +238,7 @@ describe('AppStore', () => {
           organisation: { code: 'myorg', isDedicated: true },
         },
       });
-      expect(store.getPublicInterfaceLink()).toBe('/myorg');
+      expect(store.publicInterfaceLink()).toBe('/myorg');
     });
   });
 });

--- a/projects/sonar/src/app/store/app.store.ts
+++ b/projects/sonar/src/app/store/app.store.ts
@@ -8,13 +8,18 @@ import { EMPTY, Observable } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 import { User, UserOrganisation } from '../models';
 
-export type AppSettings = { document_identifier_link: unknown };
+export type language = { code: string, name: string }
+
+export type AppSettings = {
+  document_identifier_link: unknown,
+  availableLanguages: language[]
+};
 
 export type AppState = {
   user: User | null;
   organisation: UserOrganisation | null;
   permissions: Record<string, Record<string, boolean>> | null;
-  settings: AppSettings | null;
+  settings: AppSettings;
 };
 
 export type AppStoreType = InstanceType<typeof AppStore>;
@@ -25,10 +30,23 @@ export const AppStore = signalStore(
     user: null,
     organisation: null,
     permissions: null,
-    settings: null,
+    settings: {
+      document_identifier_link: {},
+      availableLanguages: []
+    },
   }),
-  withComputed((store) => ({
+  withComputed((store, apiService = inject(ApiService)) => ({
     isLogged: () => store.user() !== null,
+    availableLanguages: () => store.settings()?.availableLanguages ?? [],
+    isDedicatedOrganisation: () => {
+      const org = store.organisation();
+      return org != null && 'isDedicated' in org && !!org.isDedicated;
+    },
+    userRefEndpoint: () => apiService.getRefEndpoint('users', store.user()!.pid),
+    publicInterfaceLink: () => {
+      const org = store.organisation();
+      return org?.isDedicated ? `/${org.code}` : '/';
+    },
   })),
   withMethods((store, http = inject(HttpClient), apiService = inject(ApiService)) => ({
     load(): Observable<void> {
@@ -38,8 +56,10 @@ export const AppStore = signalStore(
         )
         .pipe(
           tap((response) => {
-            const settings = response.settings ?? null;
-            patchState(store, { settings });
+            const { settings } = response;
+            if (settings) {
+              patchState(store, { settings });
+            }
             if (response.metadata?.is_user) {
               const { organisation, permissions, ...rest } = response.metadata;
               patchState(store, {
@@ -72,18 +92,5 @@ export const AppStore = signalStore(
       return store.user()?.pid === pid;
     },
 
-    isDedicatedOrganisation(): boolean {
-      const org = store.organisation();
-      return org != null && 'isDedicated' in org && !!org.isDedicated;
-    },
-
-    getUserRefEndpoint(): string {
-      return apiService.getRefEndpoint('users', store.user()!.pid);
-    },
-
-    getPublicInterfaceLink(): string {
-      const org = store.organisation();
-      return org?.isDedicated ? `/${org.code}` : '/';
-    },
   }))
 );

--- a/projects/sonar/src/environments/environment.prod.ts
+++ b/projects/sonar/src/environments/environment.prod.ts
@@ -12,5 +12,6 @@ export const environment = {
   translationsURLs: [
     '/static/node_modules/@rero/sonar-ui/dist/sonar/browser/assets/i18n/${lang}.json',
     '/api/translations/${lang}.json'
-  ]
+  ],
+  ngCoreAssetsUrl: '/static/node_modules/@rero/sonar-ui/dist/sonar/browser'
 };

--- a/projects/sonar/src/environments/environment.ts
+++ b/projects/sonar/src/environments/environment.ts
@@ -16,6 +16,7 @@ export const environment = {
   translationsURLs: [
     '/assets/i18n/${lang}.json',
     '/api/translations/${lang}.json'
-  ]
+  ],
+  ngCoreAssetsUrl: ''
 };
 


### PR DESCRIPTION
* Copy ng-core i18n and languages assets in angular.json
* Add ngCoreAssetsUrl to environment files and AppConfigService
* Replace AppTranslateLoader with CoreTranslateLoader-based implementation
* Add AppTranslateService extending NgCoreTranslateService with locales
* Register AppTranslateService as NgCoreTranslateService alias in app.config
* Migrate getUserRefEndpoint and getPublicInterfaceLink to computed signals
* Add specs for AppTranslateLoader and AppTranslateService
* Add CI support for building and installing a local ng-core via .ng-core-ref