### PR TITLE
feat(documents): add export formats

### DIFF
--- a/projects/sonar/src/app/record/document/detail/detail.component.html
+++ b/projects/sonar/src/app/record/document/detail/detail.component.html
@@ -404,3 +404,5 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 </p-dialog>
 }
 }
+
+<sonar-document-actions [recordData]="recordData()" />

--- a/projects/sonar/src/app/record/document/detail/detail.component.ts
+++ b/projects/sonar/src/app/record/document/detail/detail.component.ts
@@ -30,6 +30,7 @@ import { FileComponent } from '../file/file.component';
 import { LicensePipe } from '../license.pipe';
 import { ContributionsComponent } from './contributions/contributions.component';
 import { CitationActionComponent } from '../citation/citation-action/citation-action.component';
+import { DocumentActionsComponent } from '../document-actions/document-actions.component';
 
 @Component({
     templateUrl: './detail.component.html',
@@ -63,7 +64,8 @@ import { CitationActionComponent } from '../citation/citation-action/citation-ac
     JoinPipe,
     LanguageValuePipe,
     LicensePipe,
-    CitationActionComponent
+    CitationActionComponent,
+    DocumentActionsComponent,
 ],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/projects/sonar/src/app/record/document/document-actions/document-actions.component.html
+++ b/projects/sonar/src/app/record/document/document-actions/document-actions.component.html
@@ -1,0 +1,15 @@
+<!--
+SPDX-FileCopyrightText: Fondation RERO+
+SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+<p-panel [header]="'Export to…'|translate" [dt]="{ root: { background: 'white' }, header: { background: '{surface.100}' } }">
+  <div class="ui:flex ui:flex-wrap ui:gap-2 ui:items-start ui:p-2">
+    @for(format of exportFormats(); track format.format) {
+      <a pButton [href]="exportUrl(format.format)"
+        class="ui:p-2 ui:flex ui:flex-col ui:items-center ui:justify-center ui:w-26 ui:border-none ui:bg-transparent ui:cursor-pointer ui:no-underline">
+        <i class="fa-2x ui:text-muted-color" [class]="format.icon" aria-hidden="true"></i>
+        <span class="ui:text-center ui:text-xs ui:text-muted-color">{{ format.label | translate }}</span>
+      </a>
+    }
+  </div>
+</p-panel>

--- a/projects/sonar/src/app/record/document/document-actions/document-actions.component.spec.ts
+++ b/projects/sonar/src/app/record/document/document-actions/document-actions.component.spec.ts
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { ApiService, CoreTranslateLoader } from '@rero/ng-core';
+import { AppStore } from '../../../store/app.store';
+import { DocumentActionsComponent } from './document-actions.component';
+
+const API_BASE = '/api/documents';
+
+const apiServiceMock = {
+  getEndpointByType: vi.fn().mockReturnValue(API_BASE)
+};
+
+const EXPORT_FORMATS = [
+  { format: 'bibtex', icon: 'fa-file-text-o', label: 'BibTeX' },
+  { format: 'ris', icon: 'fa-file-text-o', label: 'RIS' },
+];
+
+const appStoreMock = {
+  settings: signal({
+    document_identifier_link: {},
+    document_serializers: EXPORT_FORMATS,
+  })
+};
+
+describe('DocumentActionsComponent', () => {
+  let component: DocumentActionsComponent;
+  let fixture: ComponentFixture<DocumentActionsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          loader: { provide: BaseTranslateLoader, useClass: CoreTranslateLoader }
+        }),
+        DocumentActionsComponent
+      ],
+      providers: [
+        { provide: ApiService, useValue: apiServiceMock },
+        { provide: AppStore, useValue: appStoreMock },
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocumentActionsComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('recordData', { pid: 'doc-123' });
+    fixture.detectChanges();
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('exportFormats', () => {
+    it('should return serializers from store settings', () => {
+      expect(component.exportFormats()).toEqual(EXPORT_FORMATS);
+    });
+
+    it('should return empty array when settings is null', () => {
+      appStoreMock.settings.set(null as unknown as ReturnType<typeof appStoreMock.settings>);
+      expect(component.exportFormats()).toEqual([]);
+      appStoreMock.settings.set({ document_identifier_link: {}, document_serializers: EXPORT_FORMATS });
+    });
+  });
+
+  describe('exportUrl()', () => {
+    it('should build correct export URL', () => {
+      expect(component.exportUrl('bibtex')).toBe(`${API_BASE}/doc-123?format=bibtex`);
+    });
+
+    it('should use the pid from recordData', () => {
+      fixture.componentRef.setInput('recordData', { pid: 'other-pid' });
+      expect(component.exportUrl('ris')).toBe(`${API_BASE}/other-pid?format=ris`);
+    });
+  });
+});

--- a/projects/sonar/src/app/record/document/document-actions/document-actions.component.ts
+++ b/projects/sonar/src/app/record/document/document-actions/document-actions.component.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { TranslatePipe } from '@ngx-translate/core';
+import { ApiService } from '@rero/ng-core';
+import { ButtonDirective } from 'primeng/button';
+import { AppStore } from '../../../store/app.store';
+import { Panel } from 'primeng/panel';
+
+@Component({
+  selector: 'sonar-document-actions',
+  imports: [ButtonDirective, TranslatePipe, Panel],
+  templateUrl: './document-actions.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocumentActionsComponent {
+
+  private apiService = inject(ApiService);
+  protected store = inject(AppStore);
+
+  recordData = input.required<Record<string, unknown>>();
+
+  exportFormats = computed(() => this.store.settings()?.document_serializers ?? []);
+
+  exportUrl(format: string): string {
+    const pid = this.recordData().pid as string;
+    return `${this.apiService.getEndpointByType('documents', true)}/${pid}?format=${format}`;
+  }
+}

--- a/projects/sonar/src/app/store/app.store.spec.ts
+++ b/projects/sonar/src/app/store/app.store.spec.ts
@@ -54,7 +54,7 @@ describe('AppStore', () => {
       expect(store.user()).toBeNull();
       expect(store.organisation()).toBeNull();
       expect(store.permissions()).toBeNull();
-      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [] });
+      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [], document_serializers: [] });
     });
 
     it('isLogged should be false initially', () => {
@@ -70,7 +70,7 @@ describe('AppStore', () => {
       expect(store.user()).toMatchObject({ pid: '1', role: 'submitter' });
       expect(store.organisation()).toEqual({ code: 'org1', pid: 'o1', isDedicated: false });
       expect(store.permissions()).toEqual(loggedUserResponse.metadata.permissions);
-      expect(store.settings()).toEqual(loggedUserResponse.settings);
+      expect(store.settings()).toEqual({ ...loggedUserResponse.settings, availableLanguages: [], document_serializers: [] });
     });
 
     it('should not set user if is_user is false', () => {
@@ -81,7 +81,7 @@ describe('AppStore', () => {
       });
 
       expect(store.user()).toBeNull();
-      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [] });
+      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [], document_serializers: [] });
     });
 
     it('should store settings even when user is not logged in', () => {
@@ -91,7 +91,20 @@ describe('AppStore', () => {
       });
 
       expect(store.user()).toBeNull();
-      expect(store.settings()).toEqual({ document_identifier_link: {} });
+      expect(store.settings()).toEqual({ document_identifier_link: {}, availableLanguages: [], document_serializers: [] });
+    });
+
+    it('should store document_serializers with their label', () => {
+      const documentSerializers = [
+        { format: 'bibtex', icon: 'fa-file-text-o', label: 'BibTeX' },
+        { format: 'ris', icon: 'fa-file-text-o', label: 'RIS' },
+      ];
+      store.load().subscribe();
+      httpTesting.expectOne('/api/logged-user/?resolve=1').flush({
+        settings: { document_identifier_link: {}, document_serializers: documentSerializers },
+      });
+
+      expect(store.settings()?.document_serializers).toEqual(documentSerializers);
     });
 
     it('should not store organisation and permissions on user object', () => {

--- a/projects/sonar/src/app/store/app.store.ts
+++ b/projects/sonar/src/app/store/app.store.ts
@@ -1,18 +1,25 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import { HttpClient } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { patchState, signalStore, withComputed, withMethods, withState } from '@ngrx/signals';
 import { ApiService } from '@rero/ng-core';
-import { HttpClient } from '@angular/common/http';
 import { EMPTY, Observable } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
 import { User, UserOrganisation } from '../models';
 
 export type language = { code: string, name: string }
 
+export type DocumentSerializer = {
+  format: string;
+  icon: string;
+  label: string;
+};
+
 export type AppSettings = {
-  document_identifier_link: unknown,
-  availableLanguages: language[]
+  document_identifier_link: unknown;
+  availableLanguages: language[];
+  document_serializers: DocumentSerializer[];
 };
 
 export type AppState = {
@@ -32,7 +39,8 @@ export const AppStore = signalStore(
     permissions: null,
     settings: {
       document_identifier_link: {},
-      availableLanguages: []
+      availableLanguages: [],
+      document_serializers: []
     },
   }),
   withComputed((store, apiService = inject(ApiService)) => ({
@@ -58,7 +66,7 @@ export const AppStore = signalStore(
           tap((response) => {
             const { settings } = response;
             if (settings) {
-              patchState(store, { settings });
+              patchState(store, { settings: { ...store.settings(), ...settings } });
             }
             if (response.metadata?.is_user) {
               const { organisation, permissions, ...rest } = response.metadata;


### PR DESCRIPTION
* Add DocumentActionsComponent to export documents to bibliographic
  formats from the detail page
* Type document_serializers (format, icon, label) in AppSettings
* Merge settings on load() instead of overwriting them, so fields
  missing from the backend response keep their default value