### PR TITLE
ci: add continuous translation extraction workflow

### DIFF
--- a/.github/workflows/extract-translations.yml
+++ b/.github/workflows/extract-translations.yml
@@ -1,0 +1,99 @@
+# Continuous localization buffer (the CI owns the template, Weblate owns the
+# translations). Keeps the `translations` branch equal to `staging` plus the
+# not-yet-released translations: it merges (never rebases) `staging` into the
+# buffer, regenerates the message template (messages.json) from the code, and
+# pushes back to `translations` only when the set of source messages changes. It
+# never writes the language files -- Weblate is their sole editor, via the
+# monolingual base file. The two actors therefore touch disjoint files
+# (CI: assets/i18n/messages.json, Weblate: assets/i18n/<lang>.json), so a
+# CI<->Weblate conflict is impossible by construction. The buffer is
+# squash-merged into `staging` once per release, which must be followed
+# immediately by merging `staging` back into `translations`. The squash leaves no
+# trace of the buffer in staging's ancestry, so until that resync lands the merge
+# base is stale and the next nightly merge conflicts on the language files -- even
+# with Weblate as their only writer.
+#
+# Deliberately does NOT run `update_catalog`: in a monolingual format Weblate
+# derives the string list from the base file (messages.json), so pushing a key
+# there is enough to make it appear untranslated in every language -- this is the
+# msgmerge equivalent, and it needs no add-on. The runtime fallback to English is
+# provided by the "Remove blank strings" add-on, which keeps untranslated keys out
+# of the language files (ngx-translate then returns the key, i.e. the English
+# source; an empty value would render as blank).
+#
+# Invariants: no rebase, no force-push, no branch lock.
+
+name: Extract translations
+
+on:
+  schedule:
+    - cron: '0 2 * * *' # every day at 02:00 UTC (aligns with Weblate's 24h commit window)
+  workflow_dispatch:
+
+concurrency:
+  group: extract-translations # one run at a time -> no CI<->CI race
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  extract:
+    # Never run on forks: the job pushes to rero/sonar-ui and would always fail
+    # elsewhere. Skipped (not failed) on any other repository.
+    if: github.repository == 'rero/sonar-ui'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: translations
+          fetch-depth: 0
+          persist-credentials: false # token is configured just before the push (see below)
+
+      # Merge before installing, so the extraction runs against staging's code
+      # *and* staging's lockfile.
+      - name: Bring staging code into the buffer
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin staging
+          git merge --no-edit origin/staging # MERGE (never rebase) -> translations is never rewritten
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm ci
+
+      - name: Extract message template
+        run: pnpm run extract_messages # regenerates messages.json (source keys only; Weblate owns <lang>.json)
+
+      - name: Commit & push if the template changed
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TEMPLATE='projects/sonar/src/assets/i18n/messages.json'
+          # Unlike pybabel, ngx-translate-extract writes no timestamp header, so a
+          # plain diff is enough to skip content-free commits.
+          if git diff --quiet -- "$TEMPLATE"; then
+            echo "No template changes."; exit 0
+          fi
+          git add "$TEMPLATE"
+          git commit -m "chore(i18n): extract messages"
+          # Set the token only now, so it is never in git config during dependency install.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          # Absorb any concurrent Weblate commit (merge, never rebase), then push; retry the race.
+          for i in 1 2 3; do
+            git fetch origin translations \
+              && git merge --no-edit origin/translations \
+              && git push origin translations && exit 0
+            git merge --abort 2>/dev/null || true
+            echo "attempt $i failed, retrying"; sleep 5
+          done
+          echo "::error::failed to push to translations after 3 attempts"; exit 1


### PR DESCRIPTION
Set up the continuous localization loop on the `translations` buffer branch, mirroring the topology validated on sonar: the CI owns the message template, Weblate owns the translations, so the two write disjoint files and cannot conflict by construction.

* Merge (never rebase) `staging` into the buffer, regenerate messages.json with extract_messages, and push back only when the set of source messages changes
* Merge before installing, so the extraction runs against staging's code and staging's lockfile
* Skip the job outside rero/sonar-ui, which forks cannot push to
* Set the push token only after the dependency install steps, so it is never in git config while third-party code runs
* Guard the commit with a plain git diff: unlike pybabel, ngx-translate -extract writes no timestamp header, so no POT-Creation-Date to ignore
* Do not run update_catalog: in a monolingual format Weblate derives the string list from the base file, which is the msgmerge equivalent, and the "Remove blank strings" add-on keeps untranslated keys out of the language files so ngx-translate falls back to the English source