### PR TITLE
fix(routing): fix public view detailUrl resolution

### DIFF
--- a/projects/sonar/src/app/app.routes.spec.ts
+++ b/projects/sonar/src/app/app.routes.spec.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ActivatedRouteSnapshot } from '@angular/router';
+import { publicSearchViewResolver } from './app.routes';
+
+describe('publicSearchViewResolver', () => {
+  const buildRoute = (params: Record<string, string>, data: Record<string, unknown>): ActivatedRouteSnapshot =>
+    ({ params, data }) as ActivatedRouteSnapshot;
+
+  it('should set detailUrl at the root of route.data, not on the record type', () => {
+    const types = [{ key: 'documents' }];
+    const route = buildRoute({ view: 'global' }, { types });
+
+    publicSearchViewResolver(route, undefined as never);
+
+    expect(route.data['detailUrl']).toBe('/global/:type/:pid');
+    expect(types[0]['detailUrl']).toBeUndefined();
+  });
+
+  it('should set preFilters on the record type', () => {
+    const types = [{ key: 'documents' }];
+    const route = buildRoute({ view: 'global' }, { types });
+
+    publicSearchViewResolver(route, undefined as never);
+
+    expect(types[0]['preFilters']).toEqual({ view: 'global' });
+  });
+
+  it('should do nothing when there is no view param', () => {
+    const types = [{ key: 'documents' }];
+    const route = buildRoute({}, { types });
+
+    publicSearchViewResolver(route, undefined as never);
+
+    expect(route.data['detailUrl']).toBeUndefined();
+    expect(types[0]['preFilters']).toBeUndefined();
+  });
+
+  it('should do nothing when there are no types', () => {
+    const route = buildRoute({ view: 'global' }, { types: [] });
+
+    publicSearchViewResolver(route, undefined as never);
+
+    expect(route.data['detailUrl']).toBeUndefined();
+  });
+});

--- a/projects/sonar/src/app/app.routes.ts
+++ b/projects/sonar/src/app/app.routes.ts
@@ -35,11 +35,11 @@ const recordMatcher = (type: string) => (url: UrlSegment[]) => {
   return null;
 };
 
-const publicSearchViewResolver: ResolveFn<void> = (route: ActivatedRouteSnapshot) => {
+export const publicSearchViewResolver: ResolveFn<void> = (route: ActivatedRouteSnapshot) => {
   const view = route.params['view'];
   const types = route.data['types'] as Record<string, unknown>[];
   if (view && types?.[0]) {
-    types[0]['detailUrl'] = `/${view}/:type/:pid`;
+    route.data['detailUrl'] = `/${view}/:type/:pid`;
     types[0]['preFilters'] = { view };
   }
 };


### PR DESCRIPTION
ng-core's record-search-result component reads detailUrl from store.routeConfig() (RouteConfig, at the root of route.data), not from the record type config. Setting it on types[0] left it empty, so the component fell back to a relative "detail/:pid" link resolved against the current URL — producing /:view/search/documents/detail/:pid instead of the intended absolute /:view/documents/:pid.