### PR TITLE
fix(routing): fix contributor link on the shared detail page

### DIFF
--- a/projects/sonar/src/app/record/document/contribution/contribution.component.spec.ts
+++ b/projects/sonar/src/app/record/document/contribution/contribution.component.spec.ts
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: Fondation RERO+
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { CoreTranslateLoader } from '@rero/ng-core';
+import { ActivatedRoute } from '@angular/router';
+import { IContribution } from '../contribution.interface';
+import { ContributionComponent } from './contribution.component';
+
+const CONTRIBUTOR: IContribution = {
+  agent: { type: 'bf:Person', preferred_name: 'Lea Weber' },
+  role: ['cre'],
+};
+
+const buildActivatedRoute = (paramMaps: Record<string, string>[]): ActivatedRoute => {
+  let route: { snapshot: { paramMap: { get: (key: string) => string | null } }; parent: unknown } | null = null;
+  for (const params of [...paramMaps].reverse()) {
+    route = {
+      snapshot: { paramMap: { get: (key: string) => params[key] ?? null } },
+      parent: route,
+    };
+  }
+  return route as unknown as ActivatedRoute;
+};
+
+describe('ContributionComponent', () => {
+  let fixture: ComponentFixture<ContributionComponent>;
+
+  const createComponent = async (activatedRoute: ActivatedRoute) => {
+    await TestBed.configureTestingModule({
+      imports: [
+        TranslateModule.forRoot({
+          loader: { provide: BaseTranslateLoader, useClass: CoreTranslateLoader }
+        }),
+        ContributionComponent
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: activatedRoute },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ContributionComponent);
+    fixture.componentRef.setInput('contributor', CONTRIBUTOR);
+  };
+
+  describe('route()', () => {
+    it('should build the public search link from the :view route param when no [view] input is set', async () => {
+      await createComponent(buildActivatedRoute([{ view: 'global' }, {}]));
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.route()).toEqual(['/', 'global', 'search', 'documents']);
+    });
+
+    it('should walk up parent routes to find the :view param', async () => {
+      await createComponent(buildActivatedRoute([{ view: 'global' }, { pid: '546' }]));
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.route()).toEqual(['/', 'global', 'search', 'documents']);
+    });
+
+    it('should build the admin route when no :view param is found anywhere', async () => {
+      await createComponent(buildActivatedRoute([{ pid: '546' }]));
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.route()).toEqual(['/records', 'documents']);
+    });
+
+    it('should prefer the explicit [view] input over the route param', async () => {
+      await createComponent(buildActivatedRoute([{ view: 'global' }]));
+      fixture.componentRef.setInput('view', 'dedicated-org');
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.route()).toEqual(['/', 'dedicated-org', 'search', 'documents']);
+    });
+  });
+});

--- a/projects/sonar/src/app/record/document/contribution/contribution.component.ts
+++ b/projects/sonar/src/app/record/document/contribution/contribution.component.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Fondation RERO+
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { IContribution } from '../contribution.interface';
 import { NgClass } from '@angular/common';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, RouterLink } from '@angular/router';
 import { IdentifierComponent } from '../../identifier/identifier.component';
 import { Tooltip } from 'primeng/tooltip';
 import { TranslatePipe } from '@ngx-translate/core';
@@ -21,13 +21,29 @@ const MEETING_FIELDS: MeetingField[] = ['number', 'date', 'place'];
 })
 export class ContributionComponent {
 
+  private activatedRoute = inject(ActivatedRoute);
+
   contributor = input.required<IContribution>();
 
   view = input<string>();
 
   viewType = input<'brief' | 'detail'>('brief');
 
-  route = computed(() => this.view() ? ['/', this.view(), 'search', 'documents'] : ['/records', 'documents']);
+  private routeView = computed(() => {
+    let current: ActivatedRoute | null = this.activatedRoute;
+    while (current) {
+      const view = current.snapshot.paramMap.get('view');
+      if (view) {
+        return view;
+      }
+      current = current.parent;
+    }
+    return null;
+  });
+
+  private resolvedView = computed(() => this.view() ?? this.routeView());
+
+  route = computed(() => this.resolvedView() ? ['/', this.resolvedView() as string, 'search', 'documents'] : ['/records', 'documents']);
 
   meetingInfo = computed(() => {
     const { agent } = this.contributor();


### PR DESCRIPTION
DetailComponent is shared between the admin route
(/records/documents/detail/:pid) and the public per-organisation route (/:view/search/documents/detail/:pid), but ContributionComponent only built the public search link from an explicit [view] input that neither ContributionsComponent nor DetailComponent ever passed down. The contributor link on the detail page therefore always fell back to the admin route (/records/documents?q=...), even in the public view.

Fall back to reading the :view route param (walking up parent routes, same pattern as DetailComponent.typeConfig) when the input isn't set, so the link is derived from context wherever the component is used.