### PR TITLE
fix(deposit): fix the Continue button after a breadcrumb navigation

### DIFF
--- a/projects/sonar/src/app/deposit/editor/editor.component.html
+++ b/projects/sonar/src/app/deposit/editor/editor.component.html
@@ -17,7 +17,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
   }
 </div>
 <!-- metadata editor -->
-<formly-form [form]="form()" [model]="model()" [fields]="fields()" [class]="'step-' + currentStep" />
+<formly-form [form]="form()" [model]="model()" [fields]="fields()" [class]="'step-' + currentStep()" />
 
 <p-dialog [header]="'Import from swisscovery' | translate" [modal]="true" [(visible)]="importModalIsVisible"
   class="ui:w-[40lvw]">

--- a/projects/sonar/src/app/deposit/editor/editor.component.spec.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.spec.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { DatePipe } from '@angular/common';
 import { provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
-import { signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterModule } from '@angular/router';
-import { FormlyModule } from '@ngx-formly/core';
+import { FieldType, FormlyModule } from '@ngx-formly/core';
 import { TranslateLoader as BaseTranslateLoader, TranslateModule } from '@ngx-translate/core';
 import { CoreConfigService, CoreTranslateLoader } from '@rero/ng-core';
 import { AppConfigService } from '../../app-config.service';
@@ -46,6 +46,14 @@ const appStoreMock: any = {
   checkUserReference: vi.fn().mockReturnValue(false),
 };
 
+/** Minimal field type, the real ones come from ng-core and are not needed here. */
+@Component({
+  selector: 'sonar-stub-field',
+  template: '',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class StubFieldComponent extends FieldType {}
+
 describe('EditorComponent', () => {
   let component: EditorComponent;
   let fixture: ComponentFixture<EditorComponent>;
@@ -60,7 +68,12 @@ describe('EditorComponent', () => {
           loader: { provide: BaseTranslateLoader, useClass: CoreTranslateLoader },
         }),
         FormsModule,
-        FormlyModule.forRoot({}),
+        FormlyModule.forRoot({
+          types: [
+            { name: 'object', extends: 'formly-group' },
+            { name: 'string', component: StubFieldComponent },
+          ],
+        }),
         DialogModule,
         EditorComponent,
       ],
@@ -91,5 +104,60 @@ describe('EditorComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('when navigating between steps', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        metadata: {
+          type: 'object',
+          properties: { title: { type: 'string' } },
+          required: ['title'],
+        },
+        contributors: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          required: ['name'],
+        },
+      },
+    };
+
+    beforeEach(() => {
+      depositStoreMock.schema.set(schema);
+      depositStoreMock.deposit.set({
+        pid: '1',
+        step: 'contributors',
+        status: 'in_progress',
+        metadata: {},
+        contributors: {},
+      });
+      fixture.componentRef.setInput('steps', ['metadata', 'contributors']);
+      fixture.componentRef.setInput('currentStep', 'contributors');
+      fixture.detectChanges();
+    });
+
+    it('should drop the controls of the previous step', () => {
+      expect(Object.keys(component.form().controls)).toEqual(['contributors']);
+
+      fixture.componentRef.setInput('currentStep', 'metadata');
+      fixture.detectChanges();
+
+      expect(Object.keys(component.form().controls)).toEqual(['metadata']);
+    });
+
+    it('should save when the current step is valid, whatever the previous step was', () => {
+      // the previous step is left invalid (its required field is empty)
+      expect(component.form().valid).toBe(false);
+
+      fixture.componentRef.setInput('currentStep', 'metadata');
+      fixture.detectChanges();
+      component.form().get('metadata.title')!.setValue('A title');
+      fixture.detectChanges();
+
+      component.save();
+
+      expect(depositStoreMock.update).toHaveBeenCalled();
+    });
   });
 });

--- a/projects/sonar/src/app/deposit/editor/editor.component.ts
+++ b/projects/sonar/src/app/deposit/editor/editor.component.ts
@@ -8,6 +8,7 @@ import {
   effect,
   inject,
   input,
+  linkedSignal,
   signal
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -64,7 +65,15 @@ export class EditorComponent {
   currentStep = input.required<string>();
   steps = input.required<string[]>();
 
-  form = signal<UntypedFormGroup>(new UntypedFormGroup({}));
+  /**
+   * A fresh form group is required on each step, as formly only clears the validators of the
+   * controls of the previous step and leaves them registered. Such a leftover control keeps its
+   * invalid status forever and silently blocks the save of every following step.
+   */
+  form = linkedSignal<string, UntypedFormGroup>({
+    source: this.currentStep,
+    computation: () => new UntypedFormGroup({}),
+  });
   model = signal<Record<string, unknown>>({});
   fields = signal<FormlyFieldConfig[]>([]);
   importModalIsVisible = signal(false);


### PR DESCRIPTION
EditorComponent isn't re-created when the step changes — the route is :step, so a breadcrumb click only updates a route param — and it held a single UntypedFormGroup for the whole deposit. When the fields change, formly's clearControl() recursively drops the validators of the previous step's controls but leaves them registered and never recomputes their status; registerControl() then only setControl()s the key of the current step. A control left over from an invalid step therefore kept its INVALID status forever, so save() bailed out on form.valid, without a request, a navigation, or a visible error since the offending field is no longer rendered. Reproducible by leaving contributors with an empty required field and jumping back to metadata from the breadcrumb; opening the step by URL always worked, as the component is then fresh.

Rebuild the form group on each step change with a linkedSignal on currentStep. A deposit change alone (swisscovery import, PDF extraction, save) doesn't reset it, so those flows are unaffected.

Also fix the formly-form class binding, which concatenated the currentStep signal itself instead of its value.